### PR TITLE
Add explicit parameter type annotations to filter definitions

### DIFF
--- a/src/filters/bitmap/ClaheFilter.h
+++ b/src/filters/bitmap/ClaheFilter.h
@@ -11,13 +11,15 @@ struct ClaheFilter : public FilterTyped<Bitmap, Bitmap>
             "Tiles X",
             1.0f,
             64.0f,
-            8.0f
+            8.0f,
+            FilterParameter::Int
         };
         m_parameters["tilesY"] = FilterParameter{
             "Tiles Y",
             1.0f,
             64.0f,
-            8.0f
+            8.0f,
+            FilterParameter::Int
         };
         m_parameters["clipLimit"] = FilterParameter{
             "Clip Limit (0=off)",

--- a/src/filters/bitmap/ConcentricOutlineFilter.h
+++ b/src/filters/bitmap/ConcentricOutlineFilter.h
@@ -15,13 +15,15 @@ struct ConcentricOutlineFilter : public FilterTyped<Bitmap, PathSet>
             "Threshold",
             0.0f,
             255.0f,
-            128.0f
+            128.0f,
+            FilterParameter::Int
         };
         m_parameters["spacing_px"] = FilterParameter{
             "Spacing (px)",
             1.0f,
             50.0f,
-            2.0f
+            2.0f,
+            FilterParameter::Int
         };
     }
 

--- a/src/filters/bitmap/FloatToPathFilter.h
+++ b/src/filters/bitmap/FloatToPathFilter.h
@@ -6,8 +6,8 @@ struct FloatToPathFilter : public FilterTyped<FloatImage, PathSet>
 {
     FloatToPathFilter()
     {
-        m_parameters["maximaRadius"] = FilterParameter{"maxima radius (px)", 1.0f, 7.0f, 1.0f};
-        m_parameters["connectRadius"] = FilterParameter{"connect radius (px)", 1.0f, 7.0f, 1.0f};
+        m_parameters["maximaRadius"] = FilterParameter{"maxima radius (px)", 1.0f, 7.0f, 1.0f, FilterParameter::Int};
+        m_parameters["connectRadius"] = FilterParameter{"connect radius (px)", 1.0f, 7.0f, 1.0f, FilterParameter::Int};
     }
 
     const char *name() const override { return "Float Maxima to Paths"; }

--- a/src/filters/bitmap/FlowFieldHatchFilter.h
+++ b/src/filters/bitmap/FlowFieldHatchFilter.h
@@ -26,19 +26,22 @@ struct FlowFieldHatchFilter : public FilterTyped<Bitmap, PathSet>
             "Threshold",
             0.0f,
             255.0f,
-            128.0f
+            128.0f,
+            FilterParameter::Int
         };
         m_parameters["seed_spacing_px"] = FilterParameter{
             "Seed Spacing (px)",
             2.0f,
             50.0f,
-            8.0f
+            8.0f,
+            FilterParameter::Int
         };
         m_parameters["max_connect_distance_px"] = FilterParameter{
             "Max Connect (px)",
             1.0f,
             100.0f,
-            20.0f
+            20.0f,
+            FilterParameter::Int
         };
         m_parameters["flow_strength"] = FilterParameter{
             "Flow Strength",
@@ -56,7 +59,8 @@ struct FlowFieldHatchFilter : public FilterTyped<Bitmap, PathSet>
             "Clamp Radius (px)",
             1.0f,
             100.0f,
-            20.0f
+            20.0f,
+            FilterParameter::Int
         };
     }
 

--- a/src/filters/bitmap/FlowSnakeFilter.h
+++ b/src/filters/bitmap/FlowSnakeFilter.h
@@ -34,7 +34,7 @@ struct FlowSnakeFilter : public FilterTyped<Bitmap, PathSet>
 		m_parameters["eat_strength"] = FilterParameter{
 			"Eat Strength", 0.01f, 1.0f, 0.3f};
 		m_parameters["max_steps"] = FilterParameter{
-			"Max Steps", 1000.0f, 500000.0f, 100000.0f};
+			"Max Steps", 1000.0f, 500000.0f, 100000.0f, FilterParameter::Int};
 	}
 
 	const char *name() const override { return "Flow Snake"; }

--- a/src/filters/bitmap/LineHatchFilter.h
+++ b/src/filters/bitmap/LineHatchFilter.h
@@ -15,7 +15,8 @@ struct LineHatchFilter : public FilterTyped<Bitmap, PathSet>
             "Step (px)",
             1.0f,
             20.0f,
-            8.0f
+            8.0f,
+            FilterParameter::Int
         };
         m_parameters["angle_deg"] = FilterParameter{
             "Angle (deg)",
@@ -27,7 +28,8 @@ struct LineHatchFilter : public FilterTyped<Bitmap, PathSet>
             "Threshold",
             0.0f,
             255.0f,
-            128.0f
+            128.0f,
+            FilterParameter::Int
         };
     }
 

--- a/src/filters/bitmap/ThresholdFilter.h
+++ b/src/filters/bitmap/ThresholdFilter.h
@@ -11,13 +11,15 @@ struct ThresholdFilter : public FilterTyped<Bitmap, Bitmap>
             "Min",
             0.0f,
             255.0f,
-            50.0f
+            50.0f,
+            FilterParameter::Int
         };
         m_parameters["max"] = FilterParameter{
             "Max",
             0.0f,
             255.0f,
-            150.0f
+            150.0f,
+            FilterParameter::Int
         };
     }
 

--- a/src/filters/bitmap/TraceBlobsFilter.h
+++ b/src/filters/bitmap/TraceBlobsFilter.h
@@ -21,12 +21,13 @@ struct TraceBlobsFilter : public FilterTyped<Bitmap, PathSet>
             100.0f,
             8.0f
         };
-        // When enabled (>0.5), also trace inner contours (holes) fully enclosed by a blob
+        // When enabled, also trace inner contours (holes) fully enclosed by a blob
         m_parameters["traceHoles"] = FilterParameter{
-            "Trace Holes (0/1)",
+            "Trace Holes",
             0.0f,
             1.0f,
-            1.0f
+            1.0f,
+            FilterParameter::Bool
         };
     }
 

--- a/src/filters/bitmap/TraceFilter.h
+++ b/src/filters/bitmap/TraceFilter.h
@@ -13,7 +13,8 @@ struct TraceFilter : public FilterTyped<Bitmap, PathSet>
             "Threshold",
             0.0f,
             255.0f,
-            128.0f
+            128.0f,
+            FilterParameter::Int
         };
     }
 

--- a/src/filters/bitmap/VoronoiStipplingFilter.h
+++ b/src/filters/bitmap/VoronoiStipplingFilter.h
@@ -12,13 +12,15 @@ struct VoronoiStipplingFilter : public FilterTyped<Bitmap, PathSet>
             "Number of Points",
             10.0f,
             100000.0f,
-            500.0f
+            500.0f,
+            FilterParameter::Int
         };
         m_parameters["iterations"] = FilterParameter{
             "Iterations",
             1.0f,
             100.0f,
-            20.0f
+            20.0f,
+            FilterParameter::Int
         };
         m_parameters["circle_radius"] = FilterParameter{
             "Circle Radius (mm)",
@@ -36,7 +38,8 @@ struct VoronoiStipplingFilter : public FilterTyped<Bitmap, PathSet>
             "Circle Segments",
             3.0f,
             10.0f,
-            5.0f
+            5.0f,
+            FilterParameter::Int
         };
     }
 

--- a/src/filters/pathset/CurlNoiseFilter.h
+++ b/src/filters/pathset/CurlNoiseFilter.h
@@ -22,7 +22,8 @@ struct CurlNoiseFilter : public FilterTyped<PathSet, PathSet>
             "Octaves",
             1.0f,
             8.0f,
-            3.0f
+            3.0f,
+            FilterParameter::Int
         };
         m_parameters["lacunarity"] = FilterParameter{
             "Lacunarity",
@@ -40,7 +41,8 @@ struct CurlNoiseFilter : public FilterTyped<PathSet, PathSet>
             "Seed",
             0.0f,
             1000.0f,
-            0.0f
+            0.0f,
+            FilterParameter::Int
         };
     }
 

--- a/src/filters/pathset/LaplacianSmoothFilter.h
+++ b/src/filters/pathset/LaplacianSmoothFilter.h
@@ -10,7 +10,8 @@ struct LaplacianSmoothFilter : public FilterTyped<PathSet, PathSet>
 			"Iterations",
 			0.0f,
 			50.0f,
-			5.0f
+			5.0f,
+			FilterParameter::Int
 		};
 		m_parameters["weight"] = FilterParameter{
 			"Weight",

--- a/src/filters/pathset/OptimizePathsFilter.h
+++ b/src/filters/pathset/OptimizePathsFilter.h
@@ -8,10 +8,11 @@ struct OptimizePathsFilter : public FilterTyped<PathSet, PathSet>
 	OptimizePathsFilter()
 	{
 		m_parameters["mergeEnabled"] = FilterParameter{
-			"Enable Merge (0/1)",
+			"Enable Merge",
 			0.0f,
 			1.0f,
-			0.0f
+			0.0f,
+			FilterParameter::Bool
 		};
 		m_parameters["mergeDistanceMm"] = FilterParameter{
 			"Merge Distance (mm)",
@@ -20,10 +21,11 @@ struct OptimizePathsFilter : public FilterTyped<PathSet, PathSet>
 			0.0f
 		};
 		m_parameters["reorder"] = FilterParameter{
-			"Reorder (0/1)",
+			"Reorder",
 			0.0f,
 			1.0f,
-			1.0f
+			1.0f,
+			FilterParameter::Bool
 		};
 	}
 

--- a/src/filters/pathset/SmoothFilter.h
+++ b/src/filters/pathset/SmoothFilter.h
@@ -10,7 +10,8 @@ struct SmoothFilter : public FilterTyped<PathSet, PathSet>
             "Iterations",
             0.0f,
             10.0f,
-            1.0f
+            1.0f,
+            FilterParameter::Int
         };
     }
 


### PR DESCRIPTION
## Summary
This PR adds explicit `FilterParameter` type annotations to filter parameter definitions across multiple filter classes. Previously, many integer and boolean parameters were defined without explicit type information, relying on implicit type inference.

## Key Changes
- **Integer parameters**: Added `FilterParameter::Int` type annotation to 20+ parameters that represent discrete integer values (thresholds, pixel counts, iterations, etc.)
- **Boolean parameters**: Added `FilterParameter::Bool` type annotation to 4 boolean toggle parameters in OptimizePathsFilter and TraceBlobsFilter
- **Label improvements**: Updated parameter labels for boolean filters to remove "(0/1)" notation, making them more user-friendly:
  - "Enable Merge (0/1)" → "Enable Merge"
  - "Reorder (0/1)" → "Reorder"
  - "Trace Holes (0/1)" → "Trace Holes"
- **Comment update**: Updated TraceBlobsFilter comment to reflect the new boolean parameter semantics

## Affected Filters
- FlowFieldHatchFilter
- OptimizePathsFilter
- VoronoiStipplingFilter
- TraceBlobsFilter
- ClaheFilter
- ConcentricOutlineFilter
- LineHatchFilter
- ThresholdFilter
- CurlNoiseFilter
- FloatToPathFilter
- TraceFilter
- LaplacianSmoothFilter
- SmoothFilter
- FlowSnakeFilter

## Implementation Details
This change improves type safety and UI/UX by making parameter types explicit at definition time, allowing the filter framework to properly validate and display parameters according to their intended types rather than inferring from default values.

https://claude.ai/code/session_014k6ntDbA3GMHT8PJA6TtKf