### PR TITLE
Add OpenStreetMap tile generator for pen plotting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(fmt CONFIG REQUIRED)
 find_package(glog CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(GTest CONFIG REQUIRED)
+find_package(CURL REQUIRED)
 
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
   src/*.cpp
@@ -44,7 +45,7 @@ endif()
 
 target_include_directories(minotaur PRIVATE src)
 
-target_link_libraries(minotaur PRIVATE glad::glad glfw imgui::imgui glog::glog fmt::fmt nlohmann_json::nlohmann_json)
+target_link_libraries(minotaur PRIVATE glad::glad glfw imgui::imgui glog::glog fmt::fmt nlohmann_json::nlohmann_json CURL::libcurl)
 
 if(WIN32)
   target_link_libraries(minotaur PRIVATE opengl32 ole32 windowscodecs)

--- a/src/generators/GeneratorRegistry.cpp
+++ b/src/generators/GeneratorRegistry.cpp
@@ -9,6 +9,7 @@
 #include "generators/bitmap/CheckerboardGenerator.h"
 #include "generators/bitmap/RadialGenerator.h"
 #include "generators/mesh/MeshGenerator.h"
+#include "generators/pathset/OsmGenerator.h"
 
 GeneratorRegistry &GeneratorRegistry::instance()
 {
@@ -82,5 +83,11 @@ void GeneratorRegistry::initDefaults()
 		"Mesh",
 		LayerKind::PathSet,
 		[]() { return std::make_unique<MeshGenerator>(); }
+	});
+
+	reg.registerGenerator(GeneratorInfo{
+		"OSM Tiles",
+		LayerKind::PathSet,
+		[]() { return std::make_unique<OsmGenerator>(); }
 	});
 }

--- a/src/generators/pathset/OsmGenerator.h
+++ b/src/generators/pathset/OsmGenerator.h
@@ -1,0 +1,342 @@
+#pragma once
+
+#include <atomic>
+#include <cmath>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include "core/Core.h"
+#include "generators/GeneratorBase.h"
+#include "filters/Filter.h"
+#include "filters/Types.h"
+#include "utils/HttpFetcher.h"
+#include "utils/MvtDecoder.h"
+
+// OpenStreetMap vector tile generator.
+//
+// Fetches MVT tiles from OpenFreeMap (free, no API key) for a given lat/lon
+// and zoom level, decodes the protobuf geometry, and converts it to a PathSet
+// in millimetre coordinates suitable for pen plotting.
+//
+// This is an async generator: tile fetching happens on a background thread so
+// the UI remains responsive.
+//
+// Shortbread tile schema layers exposed as toggles:
+//   streets, buildings, water_polygons, water_lines, boundaries,
+//   land_use, sites, streets_labels_only (excluded by default)
+
+struct OsmGenerator : public GeneratorBase
+{
+	OsmGenerator()
+	{
+		// Location
+		m_parameters["lat"]  = FilterParameter{"Latitude",  -85.0f,  85.0f, 40.7128f};  // NYC default
+		m_parameters["lon"]  = FilterParameter{"Longitude", -180.0f, 180.0f, -74.006f};
+		m_parameters["zoom"] = FilterParameter{"Zoom", 10.0f, 16.0f, 14.0f, FilterParameter::Int};
+
+		// Output sizing
+		m_parameters["size_mm"] = FilterParameter{"Size (mm)", 10.0f, 400.0f, 200.0f};
+
+		// Tile grid: how many tiles to fetch (NxN centered on lat/lon)
+		m_parameters["tile_count"] = FilterParameter{"Tiles NxN", 1.0f, 5.0f, 1.0f, FilterParameter::Int};
+
+		// Layer toggles (0 = off, 1 = on)
+		m_parameters["layer_streets"]         = FilterParameter{"Streets",         0.0f, 1.0f, 1.0f, FilterParameter::Bool};
+		m_parameters["layer_buildings"]        = FilterParameter{"Buildings",       0.0f, 1.0f, 1.0f, FilterParameter::Bool};
+		m_parameters["layer_water_polygons"]   = FilterParameter{"Water Polygons",  0.0f, 1.0f, 1.0f, FilterParameter::Bool};
+		m_parameters["layer_water_lines"]      = FilterParameter{"Water Lines",     0.0f, 1.0f, 1.0f, FilterParameter::Bool};
+		m_parameters["layer_boundaries"]       = FilterParameter{"Boundaries",      0.0f, 1.0f, 0.0f, FilterParameter::Bool};
+		m_parameters["layer_land_use"]         = FilterParameter{"Land Use",        0.0f, 1.0f, 0.0f, FilterParameter::Bool};
+		m_parameters["layer_sites"]            = FilterParameter{"Sites",           0.0f, 1.0f, 0.0f, FilterParameter::Bool};
+		m_parameters["layer_ocean"]            = FilterParameter{"Ocean",           0.0f, 1.0f, 0.0f, FilterParameter::Bool};
+		m_parameters["layer_ferries"]          = FilterParameter{"Ferries",         0.0f, 1.0f, 0.0f, FilterParameter::Bool};
+		m_parameters["layer_public_transport"] = FilterParameter{"Public Transport",0.0f, 1.0f, 0.0f, FilterParameter::Bool};
+	}
+
+	~OsmGenerator() override
+	{
+		m_cancel.store(true);
+		if (m_worker.joinable()) m_worker.join();
+	}
+
+	const char *name() const override { return "OSM Tiles"; }
+	LayerKind outputKind() const override { return LayerKind::PathSet; }
+	uint64_t paramVersion() const override { return m_version.load(); }
+
+	// ── Async interface ─────────────────────────────────────────────────
+	bool isAsync() const override { return true; }
+
+	void startGenerate() override
+	{
+		// Cancel any in-flight work
+		m_cancel.store(true);
+		if (m_worker.joinable()) m_worker.join();
+
+		m_ready.store(false);
+		m_cancel.store(false);
+
+		// Snapshot parameters for the worker thread
+		const float lat      = m_parameters.at("lat").value;
+		const float lon      = m_parameters.at("lon").value;
+		const int   zoom     = static_cast<int>(std::lround(m_parameters.at("zoom").value));
+		const float sizeMm   = m_parameters.at("size_mm").value;
+		const int   tileN    = static_cast<int>(std::lround(m_parameters.at("tile_count").value));
+
+		// Snapshot layer toggles
+		LayerToggles toggles;
+		toggles.streets         = m_parameters.at("layer_streets").value > 0.5f;
+		toggles.buildings       = m_parameters.at("layer_buildings").value > 0.5f;
+		toggles.waterPolygons   = m_parameters.at("layer_water_polygons").value > 0.5f;
+		toggles.waterLines      = m_parameters.at("layer_water_lines").value > 0.5f;
+		toggles.boundaries      = m_parameters.at("layer_boundaries").value > 0.5f;
+		toggles.landUse         = m_parameters.at("layer_land_use").value > 0.5f;
+		toggles.sites           = m_parameters.at("layer_sites").value > 0.5f;
+		toggles.ocean           = m_parameters.at("layer_ocean").value > 0.5f;
+		toggles.ferries         = m_parameters.at("layer_ferries").value > 0.5f;
+		toggles.publicTransport = m_parameters.at("layer_public_transport").value > 0.5f;
+
+		m_worker = std::thread([this, lat, lon, zoom, sizeMm, tileN, toggles]()
+		{
+			doGenerate(lat, lon, zoom, sizeMm, tileN, toggles);
+		});
+	}
+
+	bool isReady() const override { return m_ready.load(); }
+
+	void collectResult(LayerPtr &out) override
+	{
+		if (m_worker.joinable()) m_worker.join();
+
+		std::lock_guard<std::mutex> lock(m_resultMutex);
+		auto ps = std::make_shared<PathSet>(std::move(m_result));
+		out = std::static_pointer_cast<ILayerData>(ps);
+		m_ready.store(false);
+	}
+
+	std::unique_ptr<GeneratorBase> clone() const override
+	{
+		auto copy = std::make_unique<OsmGenerator>();
+		for (const auto &kv : m_parameters)
+			copy->setParameter(kv.first, kv.second.value);
+		for (const auto &kv : m_stringParameters)
+			copy->setStringParameter(kv.first, kv.second);
+		return copy;
+	}
+
+	// Status string for UI display
+	std::string statusText() const
+	{
+		std::lock_guard<std::mutex> lock(m_statusMutex);
+		return m_statusText;
+	}
+
+private:
+	struct LayerToggles
+	{
+		bool streets = true, buildings = true, waterPolygons = true, waterLines = true;
+		bool boundaries = false, landUse = false, sites = false, ocean = false;
+		bool ferries = false, publicTransport = false;
+	};
+
+	std::thread m_worker;
+	std::atomic<bool> m_ready{false};
+	std::atomic<bool> m_cancel{false};
+
+	mutable std::mutex m_resultMutex;
+	PathSet m_result;
+
+	mutable std::mutex m_statusMutex;
+	mutable std::string m_statusText;
+
+	void setStatus(const std::string &s) const
+	{
+		std::lock_guard<std::mutex> lock(m_statusMutex);
+		m_statusText = s;
+	}
+
+	// ── Tile coordinate math ────────────────────────────────────────────
+
+	static void latLonToTile(double lat, double lon, int z, int &tx, int &ty)
+	{
+		double n = std::pow(2.0, z);
+		tx = static_cast<int>(std::floor((lon + 180.0) / 360.0 * n));
+		double latRad = lat * M_PI / 180.0;
+		ty = static_cast<int>(std::floor((1.0 - std::log(std::tan(latRad) + 1.0 / std::cos(latRad)) / M_PI) / 2.0 * n));
+		int maxTile = static_cast<int>(n) - 1;
+		tx = std::max(0, std::min(tx, maxTile));
+		ty = std::max(0, std::min(ty, maxTile));
+	}
+
+	// Returns the bounding box of a tile in Web Mercator projected coordinates (metres).
+	// We use Mercator projection so geometry stays conformal.
+	struct TileBounds { double x0, y0, x1, y1; }; // in Mercator metres
+
+	static TileBounds tileBoundsMercator(int tx, int ty, int z)
+	{
+		double n = std::pow(2.0, z);
+		// Mercator world extent ≈ 20037508.34m in each direction
+		constexpr double worldExtent = 20037508.342789244;
+		double tileSize = 2.0 * worldExtent / n;
+
+		double x0 = -worldExtent + tx * tileSize;
+		double x1 = x0 + tileSize;
+		// Y is flipped: tile y=0 is north
+		double y0 = worldExtent - (ty + 1) * tileSize;
+		double y1 = y0 + tileSize;
+		return {x0, y0, x1, y1};
+	}
+
+	// ── Layer name matching ─────────────────────────────────────────────
+
+	static bool isLayerEnabled(const std::string &layerName, const LayerToggles &t)
+	{
+		if (layerName == "streets" || layerName == "street_labels")  return t.streets;
+		if (layerName == "buildings")       return t.buildings;
+		if (layerName == "water_polygons")  return t.waterPolygons;
+		if (layerName == "water_lines")     return t.waterLines;
+		if (layerName == "boundaries")      return t.boundaries;
+		if (layerName == "land" || layerName == "land_use" || layerName == "landuse")
+			return t.landUse;
+		if (layerName == "sites")           return t.sites;
+		if (layerName == "ocean")           return t.ocean;
+		if (layerName == "ferries")         return t.ferries;
+		if (layerName == "public_transport") return t.publicTransport;
+		return false;
+	}
+
+	// ── Background work ─────────────────────────────────────────────────
+
+	void doGenerate(float lat, float lon, int zoom, float sizeMm, int tileN,
+	                const LayerToggles &toggles)
+	{
+		PathSet ps;
+		ps.paths.clear();
+
+		// Determine center tile
+		int cx, cy;
+		latLonToTile(lat, lon, zoom, cx, cy);
+
+		// Build list of tiles to fetch (NxN grid centered on cx,cy)
+		int half = tileN / 2;
+		int startX = cx - half;
+		int startY = cy - half;
+
+		// Compute the Mercator bounding box of all tiles combined
+		auto topLeft = tileBoundsMercator(startX, startY, zoom);
+		auto botRight = tileBoundsMercator(startX + tileN - 1, startY + tileN - 1, zoom);
+		double totalMercX = botRight.x1 - topLeft.x0;
+		double totalMercY = topLeft.y1 - botRight.y0;
+		double maxMerc = std::max(totalMercX, totalMercY);
+		if (maxMerc < 1e-6) maxMerc = 1.0;
+		double scale = sizeMm / maxMerc;
+
+		int tilesTotal = tileN * tileN;
+		int tilesDone = 0;
+
+		for (int dy = 0; dy < tileN && !m_cancel.load(); ++dy)
+		{
+			for (int dx = 0; dx < tileN && !m_cancel.load(); ++dx)
+			{
+				int tx = startX + dx;
+				int ty = startY + dy;
+
+				setStatus(fmt::format("Fetching tile {}/{} (z={} x={} y={})",
+					tilesDone + 1, tilesTotal, zoom, tx, ty));
+
+				std::string url = fmt::format(
+					"https://tiles.openfreemap.org/tiles/bright/{}/{}/{}.pbf",
+					zoom, tx, ty);
+
+				auto resp = HttpFetcher::get(url);
+				if (!resp.ok())
+				{
+					LOG(WARNING) << "Failed to fetch tile " << url << ": " << resp.error;
+					tilesDone++;
+					continue;
+				}
+
+				// Decode the MVT tile
+				auto tile = mvt::decodeTile(resp.data);
+
+				// This tile's Mercator bounds
+				auto tb = tileBoundsMercator(tx, ty, zoom);
+
+				// Process each layer
+				for (const auto &layer : tile.layers)
+				{
+					if (!isLayerEnabled(layer.name, toggles)) continue;
+
+					double extent = layer.extent;
+
+					for (const auto &feature : layer.features)
+					{
+						if (m_cancel.load()) break;
+
+						// Only process linestrings and polygons (render as outlines)
+						if (feature.geomType == mvt::POINT) continue;
+
+						auto geom = mvt::decodeGeometry(feature.geometry, feature.geomType);
+
+						for (const auto &ring : geom)
+						{
+							if (ring.size() < 2) continue;
+
+							Path path;
+							path.closed = (feature.geomType == mvt::POLYGON);
+
+							for (const auto &pt : ring)
+							{
+								// Convert tile-local coords to Mercator
+								double mercX = tb.x0 + (pt.x / extent) * (tb.x1 - tb.x0);
+								double mercY = tb.y1 - (pt.y / extent) * (tb.y1 - tb.y0);
+
+								// Convert to mm, centered on origin
+								double mmX = (mercX - topLeft.x0 - totalMercX * 0.5) * scale;
+								double mmY = (mercY - botRight.y0 - totalMercY * 0.5) * scale;
+
+								path.points.push_back(Vec2{
+									static_cast<float>(mmX),
+									static_cast<float>(-mmY) // flip Y for screen coords
+								});
+							}
+
+							// For closed polygons, don't duplicate the closing point
+							// (the decoder adds it, but PathSet uses the closed flag)
+							if (path.closed && path.points.size() > 1 &&
+								path.points.front().x == path.points.back().x &&
+								path.points.front().y == path.points.back().y)
+							{
+								path.points.pop_back();
+							}
+
+							if (path.points.size() >= 2)
+								ps.paths.push_back(std::move(path));
+						}
+					}
+				}
+
+				tilesDone++;
+			}
+		}
+
+		if (m_cancel.load())
+		{
+			setStatus("Cancelled");
+			return;
+		}
+
+		setStatus(fmt::format("Done - {} paths from {} tiles", ps.paths.size(), tilesDone));
+		LOG(INFO) << "OSM generator: " << ps.paths.size() << " paths from " << tilesDone << " tiles";
+
+		{
+			std::lock_guard<std::mutex> lock(m_resultMutex);
+			m_result = std::move(ps);
+		}
+		m_ready.store(true);
+	}
+};

--- a/src/utils/HttpFetcher.h
+++ b/src/utils/HttpFetcher.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <functional>
+
+#include <curl/curl.h>
+#include <glog/logging.h>
+
+// Simple synchronous HTTP GET using libcurl.
+// Designed for fetching small binary payloads (vector tiles, etc.).
+
+namespace HttpFetcher
+{
+
+namespace detail
+{
+	inline size_t writeCallback(void *contents, size_t size, size_t nmemb, void *userp)
+	{
+		auto *buf = static_cast<std::vector<uint8_t> *>(userp);
+		size_t totalBytes = size * nmemb;
+		buf->insert(buf->end(),
+			static_cast<uint8_t *>(contents),
+			static_cast<uint8_t *>(contents) + totalBytes);
+		return totalBytes;
+	}
+} // namespace detail
+
+struct Response
+{
+	long httpCode = 0;
+	std::vector<uint8_t> data;
+	std::string error;
+	bool ok() const { return httpCode == 200 && error.empty(); }
+};
+
+// Fetch a URL synchronously. Returns the response body as bytes.
+// Timeout is in seconds.
+inline Response get(const std::string &url, int timeoutSec = 15)
+{
+	Response resp;
+
+	CURL *curl = curl_easy_init();
+	if (!curl)
+	{
+		resp.error = "curl_easy_init failed";
+		return resp;
+	}
+
+	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, detail::writeCallback);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp.data);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, long(timeoutSec));
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+	curl_easy_setopt(curl, CURLOPT_USERAGENT, "Minotaur/1.0");
+	// Accept gzip if available
+	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+
+	CURLcode res = curl_easy_perform(curl);
+	if (res != CURLE_OK)
+	{
+		resp.error = curl_easy_strerror(res);
+		LOG(ERROR) << "HTTP GET failed: " << resp.error << " url=" << url;
+	}
+	else
+	{
+		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &resp.httpCode);
+		if (resp.httpCode != 200)
+		{
+			resp.error = "HTTP " + std::to_string(resp.httpCode);
+			LOG(WARNING) << "HTTP GET " << url << " -> " << resp.httpCode;
+		}
+	}
+
+	curl_easy_cleanup(curl);
+	return resp;
+}
+
+} // namespace HttpFetcher

--- a/src/utils/MvtDecoder.h
+++ b/src/utils/MvtDecoder.h
@@ -1,0 +1,338 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+// Minimal Mapbox Vector Tile (MVT) decoder.
+// Decodes protobuf wire format just enough to parse the MVT spec v2.1.
+// No external protobuf dependency required.
+
+namespace mvt
+{
+
+// ── Protobuf wire helpers ───────────────────────────────────────────────
+
+struct PbReader
+{
+	const uint8_t *ptr;
+	const uint8_t *end;
+
+	PbReader() : ptr(nullptr), end(nullptr) {}
+	PbReader(const uint8_t *data, size_t len) : ptr(data), end(data + len) {}
+
+	bool ok() const { return ptr < end; }
+
+	uint64_t readVarint()
+	{
+		uint64_t val = 0;
+		int shift = 0;
+		while (ptr < end)
+		{
+			uint8_t b = *ptr++;
+			val |= (uint64_t(b & 0x7F)) << shift;
+			if ((b & 0x80) == 0) break;
+			shift += 7;
+			if (shift > 63) break;
+		}
+		return val;
+	}
+
+	int64_t readSVarint()
+	{
+		uint64_t v = readVarint();
+		return int64_t((v >> 1) ^ -(v & 1));
+	}
+
+	uint32_t readFixed32()
+	{
+		uint32_t v = 0;
+		if (ptr + 4 <= end) { std::memcpy(&v, ptr, 4); ptr += 4; }
+		return v;
+	}
+
+	uint64_t readFixed64()
+	{
+		uint64_t v = 0;
+		if (ptr + 8 <= end) { std::memcpy(&v, ptr, 8); ptr += 8; }
+		return v;
+	}
+
+	float readFloat()
+	{
+		uint32_t bits = readFixed32();
+		float f;
+		std::memcpy(&f, &bits, 4);
+		return f;
+	}
+
+	double readDouble()
+	{
+		uint64_t bits = readFixed64();
+		double d;
+		std::memcpy(&d, &bits, 8);
+		return d;
+	}
+
+	PbReader readMessage()
+	{
+		uint64_t len = readVarint();
+		if (ptr + len > end) len = end - ptr;
+		PbReader sub(ptr, len);
+		ptr += len;
+		return sub;
+	}
+
+	std::string readString()
+	{
+		uint64_t len = readVarint();
+		if (ptr + len > end) len = end - ptr;
+		std::string s(reinterpret_cast<const char *>(ptr), len);
+		ptr += len;
+		return s;
+	}
+
+	std::vector<uint8_t> readBytes()
+	{
+		uint64_t len = readVarint();
+		if (ptr + len > end) len = end - ptr;
+		std::vector<uint8_t> b(ptr, ptr + len);
+		ptr += len;
+		return b;
+	}
+
+	// Read a packed repeated uint32 field
+	std::vector<uint32_t> readPackedUint32()
+	{
+		uint64_t len = readVarint();
+		if (ptr + len > end) len = end - ptr;
+		const uint8_t *subEnd = ptr + len;
+		std::vector<uint32_t> result;
+		while (ptr < subEnd)
+		{
+			result.push_back(static_cast<uint32_t>(readVarint()));
+		}
+		return result;
+	}
+
+	// Skip a field by wire type
+	void skip(int wireType)
+	{
+		switch (wireType)
+		{
+		case 0: readVarint(); break;
+		case 1: ptr += 8; break;
+		case 2: { uint64_t len = readVarint(); ptr += len; } break;
+		case 5: ptr += 4; break;
+		default: ptr = end; break;
+		}
+		if (ptr > end) ptr = end;
+	}
+
+	// Read field tag: returns (field_number, wire_type)
+	std::pair<int, int> readTag()
+	{
+		uint64_t v = readVarint();
+		return {int(v >> 3), int(v & 0x7)};
+	}
+};
+
+// ── MVT data structures ─────────────────────────────────────────────────
+
+enum GeomType { UNKNOWN = 0, POINT = 1, LINESTRING = 2, POLYGON = 3 };
+
+struct Value
+{
+	enum Type { STRING, FLOAT, DOUBLE, INT, UINT, SINT, BOOL } type;
+	std::string stringVal;
+	double numVal = 0;
+	bool boolVal = false;
+
+	std::string asString() const
+	{
+		if (type == STRING) return stringVal;
+		if (type == BOOL) return boolVal ? "true" : "false";
+		return std::to_string(numVal);
+	}
+};
+
+struct Feature
+{
+	uint64_t id = 0;
+	GeomType geomType = UNKNOWN;
+	std::vector<uint32_t> tags;
+	std::vector<uint32_t> geometry;
+};
+
+struct Layer
+{
+	std::string name;
+	uint32_t extent = 4096;
+	uint32_t version = 2;
+	std::vector<std::string> keys;
+	std::vector<Value> values;
+	std::vector<Feature> features;
+
+	// Look up a tag key/value pair by index into the tags array
+	std::string getTag(const Feature &f, const std::string &key) const
+	{
+		for (size_t i = 0; i + 1 < f.tags.size(); i += 2)
+		{
+			uint32_t ki = f.tags[i];
+			uint32_t vi = f.tags[i + 1];
+			if (ki < keys.size() && keys[ki] == key && vi < values.size())
+				return values[vi].asString();
+		}
+		return "";
+	}
+};
+
+struct Tile
+{
+	std::vector<Layer> layers;
+};
+
+// ── Geometry decoding ───────────────────────────────────────────────────
+
+struct Point { double x, y; };
+using Ring = std::vector<Point>;
+using Geometry = std::vector<Ring>;  // For lines: each ring is a linestring
+                                     // For polygons: exterior + holes
+
+inline int32_t zigzagDecode(uint32_t n)
+{
+	return int32_t((n >> 1) ^ -(n & 1));
+}
+
+// Decode MVT geometry commands into rings of (tile-local) points.
+// Coordinates are in tile-local integer space (0..extent).
+inline Geometry decodeGeometry(const std::vector<uint32_t> &geom, GeomType type)
+{
+	Geometry result;
+	int32_t cx = 0, cy = 0;
+	size_t i = 0;
+
+	while (i < geom.size())
+	{
+		uint32_t cmdInt = geom[i++];
+		uint32_t cmd = cmdInt & 0x7;
+		uint32_t count = cmdInt >> 3;
+
+		if (cmd == 1) // MoveTo
+		{
+			for (uint32_t j = 0; j < count && i + 1 < geom.size(); ++j)
+			{
+				cx += zigzagDecode(geom[i++]);
+				cy += zigzagDecode(geom[i++]);
+				result.push_back(Ring());
+				result.back().push_back({double(cx), double(cy)});
+			}
+		}
+		else if (cmd == 2) // LineTo
+		{
+			for (uint32_t j = 0; j < count && i + 1 < geom.size(); ++j)
+			{
+				cx += zigzagDecode(geom[i++]);
+				cy += zigzagDecode(geom[i++]);
+				if (!result.empty())
+					result.back().push_back({double(cx), double(cy)});
+			}
+		}
+		else if (cmd == 7) // ClosePath
+		{
+			if (!result.empty() && !result.back().empty())
+				result.back().push_back(result.back().front());
+		}
+	}
+	return result;
+}
+
+// ── Decoding functions ──────────────────────────────────────────────────
+
+inline Value decodeValue(PbReader &r)
+{
+	Value v;
+	v.type = Value::STRING;
+	while (r.ok())
+	{
+		auto [field, wire] = r.readTag();
+		switch (field)
+		{
+		case 1: v.stringVal = r.readString(); v.type = Value::STRING; break;
+		case 2: v.numVal = r.readFloat(); v.type = Value::FLOAT; break;
+		case 3: v.numVal = r.readDouble(); v.type = Value::DOUBLE; break;
+		case 4: v.numVal = double(int64_t(r.readVarint())); v.type = Value::INT; break;
+		case 5: v.numVal = double(r.readVarint()); v.type = Value::UINT; break;
+		case 6: v.numVal = double(r.readSVarint()); v.type = Value::SINT; break;
+		case 7: v.boolVal = r.readVarint() != 0; v.type = Value::BOOL; break;
+		default: r.skip(wire); break;
+		}
+	}
+	return v;
+}
+
+inline Feature decodeFeature(PbReader &r)
+{
+	Feature f;
+	while (r.ok())
+	{
+		auto [field, wire] = r.readTag();
+		switch (field)
+		{
+		case 1: f.id = r.readVarint(); break;
+		case 2: f.tags = r.readPackedUint32(); break;
+		case 3: f.geomType = GeomType(r.readVarint()); break;
+		case 4: f.geometry = r.readPackedUint32(); break;
+		default: r.skip(wire); break;
+		}
+	}
+	return f;
+}
+
+inline Layer decodeLayer(PbReader &r)
+{
+	Layer layer;
+	while (r.ok())
+	{
+		auto [field, wire] = r.readTag();
+		switch (field)
+		{
+		case 1: layer.name = r.readString(); break;
+		case 2: { auto sub = r.readMessage(); layer.features.push_back(decodeFeature(sub)); } break;
+		case 3: layer.keys.push_back(r.readString()); break;
+		case 4: { auto sub = r.readMessage(); layer.values.push_back(decodeValue(sub)); } break;
+		case 5: layer.extent = static_cast<uint32_t>(r.readVarint()); break;
+		case 15: layer.version = static_cast<uint32_t>(r.readVarint()); break;
+		default: r.skip(wire); break;
+		}
+	}
+	return layer;
+}
+
+inline Tile decodeTile(const uint8_t *data, size_t len)
+{
+	Tile tile;
+	PbReader r(data, len);
+	while (r.ok())
+	{
+		auto [field, wire] = r.readTag();
+		if (field == 3 && wire == 2)
+		{
+			auto sub = r.readMessage();
+			tile.layers.push_back(decodeLayer(sub));
+		}
+		else
+		{
+			r.skip(wire);
+		}
+	}
+	return tile;
+}
+
+inline Tile decodeTile(const std::vector<uint8_t> &data)
+{
+	return decodeTile(data.data(), data.size());
+}
+
+} // namespace mvt

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,8 @@
     "fmt",
     "glog",
     "nlohmann-json",
-    "gtest"
+    "gtest",
+    "curl"
   ]
 }
 


### PR DESCRIPTION
## Summary
Add a new OSM (OpenStreetMap) vector tile generator that fetches MVT tiles from OpenFreeMap, decodes them, and converts the geometry to PathSet format suitable for pen plotting. This enables users to generate plottable maps of any location at configurable zoom levels.

## Key Changes

- **OsmGenerator** (`src/generators/pathset/OsmGenerator.h`): New async generator that:
  - Fetches MVT tiles from OpenFreeMap API based on latitude, longitude, and zoom level
  - Supports configurable tile grid (NxN centered on coordinates)
  - Provides layer toggles for streets, buildings, water, boundaries, land use, sites, ocean, ferries, and public transport
  - Converts Web Mercator projected coordinates to millimeter-scale output centered on origin
  - Runs tile fetching on background thread to keep UI responsive
  - Includes status updates during generation

- **MvtDecoder** (`src/utils/MvtDecoder.h`): Minimal Mapbox Vector Tile (MVT) decoder with:
  - Protobuf wire format parser (no external protobuf dependency)
  - Support for MVT spec v2.1
  - Geometry command decoding (MoveTo, LineTo, ClosePath)
  - Feature and layer parsing with tag/value support
  - Zigzag decoding for signed integers

- **HttpFetcher** (`src/utils/HttpFetcher.h`): Simple synchronous HTTP client using libcurl:
  - Fetches binary payloads with configurable timeout
  - Automatic gzip decompression support
  - Error handling and HTTP status code checking

- **Integration**: 
  - Registered OsmGenerator in GeneratorRegistry
  - Added libcurl dependency to CMakeLists.txt and vcpkg.json

## Notable Implementation Details

- Uses Web Mercator projection to maintain conformal geometry
- Handles tile coordinate math (lat/lon to tile indices, Mercator bounds calculation)
- Properly closes polygon paths by removing duplicate closing points
- Supports cancellation of in-flight tile fetches via atomic flag
- Thread-safe result collection with mutex protection
- Cloneable generator for parameter snapshots

https://claude.ai/code/session_01E3iDfXDb8SpDQ1Jp9SZnAg