### PR TITLE
Unify addEntity template for PageModel

### DIFF
--- a/src/Page.cpp
+++ b/src/Page.cpp
@@ -13,42 +13,25 @@ static int page_next_id(const std::map<int, Entity> &ents)
     return maxId + 1;
 }
 
-int PageModel::addPathSet(const PathSet &ps)
+template <typename T>
+int PageModel::addEntity(const T &data, const std::string &name)
 {
     int id = page_next_id(entities);
     Entity e;
     e.id = id;
-    e.name = "Entity " + std::to_string(id);
-    e.payload = ps;
+    e.name = name.empty() ? "Entity " + std::to_string(id) : name;
+    e.payload = data;
     e.localToPage = Mat3();
     e.refreshFilterBase();
     entities[id] = std::move(e);
     return id;
 }
 
-void PageModel::addBitmap(const Bitmap &bm)
-{
-    int id = page_next_id(entities);
-    Entity e;
-    e.id = id;
-    e.name = "Entity " + std::to_string(id);
-    e.payload = bm;
-    e.localToPage = Mat3();
-    e.refreshFilterBase();
-    entities[id] = std::move(e);
-}
-
-void PageModel::addColorImage(const ColorImage &ci)
-{
-    int id = page_next_id(entities);
-    Entity e;
-    e.id = id;
-    e.name = "Entity " + std::to_string(id);
-    e.payload = ci;
-    e.localToPage = Mat3();
-    e.refreshFilterBase();
-    entities[id] = std::move(e);
-}
+// Explicit instantiations
+template int PageModel::addEntity<PathSet>(const PathSet&, const std::string&);
+template int PageModel::addEntity<Bitmap>(const Bitmap&, const std::string&);
+template int PageModel::addEntity<ColorImage>(const ColorImage&, const std::string&);
+template int PageModel::addEntity<FloatImage>(const FloatImage&, const std::string&);
 
 int PageModel::addGeneratedEntity(std::unique_ptr<GeneratorBase> gen, Vec2 positionMm)
 {

--- a/src/Page.h
+++ b/src/Page.h
@@ -2,14 +2,14 @@
 
 #include <map>
 #include <memory>
+#include <string>
 #include "core/Core.h"
 #include "generators/GeneratorBase.h"
 
 struct PageModel
 {
-    int addPathSet(const PathSet& ps);
-    void addBitmap(const Bitmap& bm);
-    void addColorImage(const ColorImage& ci);
+    template <typename T>
+    int addEntity(const T &data, const std::string &name = "");
 
     // Create an entity driven by a generator. The generator is immediately
     // ticked to populate the payload. Returns the new entity id.

--- a/src/screens/MainScreen.cpp
+++ b/src/screens/MainScreen.cpp
@@ -172,17 +172,17 @@ void MainScreen::onFilesDropped(const std::vector<std::string>& paths)
         ColorImage ci;
         if (ImageLoader::loadColorImage(p, ci, &err, 0.5f))
         {
-            m_page.addColorImage(ci);
+            m_page.addEntity(ci);
             LOG(INFO) << "Loaded image and added as color image: " << p;
         }
         else if (ImageLoader::loadPGM(p, bm, &err, 0.5f))
         {
-            m_page.addBitmap(bm);
+            m_page.addEntity(bm);
             LOG(INFO) << "Loaded PGM and added as bitmap: " << p;
         }
         else if (ImageLoader::loadImage(p, bm, &err, 0.5f))
         {
-            m_page.addBitmap(bm);
+            m_page.addEntity(bm);
             LOG(INFO) << "Loaded image and added as bitmap: " << p;
         }
         else
@@ -205,7 +205,7 @@ void MainScreen::onClipboardPaste()
     std::string err;
     if (ImageLoader::loadColorImageFromMemory(data.data(), data.size(), ci, &err, 0.5f))
     {
-        m_page.addColorImage(ci);
+        m_page.addEntity(ci);
         LOG(INFO) << "Pasted clipboard image as color image (" << ci.width_px << "x" << ci.height_px << ")";
     }
     else


### PR DESCRIPTION
## Summary
- Replaces three near-identical methods (`addPathSet`, `addBitmap`, `addColorImage`) with a single `addEntity<T>()` template
- All variants now consistently return `int` (the new entity ID)
- Adds optional `name` parameter for custom entity naming
- Updates all callers in `MainScreen.cpp`
- Includes explicit template instantiations for `PathSet`, `Bitmap`, `ColorImage`, and `FloatImage`

## Test plan
- [ ] Build on macOS/Windows and verify no compilation errors
- [ ] Drop an image into the app — should create an entity as before
- [ ] Drop a PGM file — should create a bitmap entity
- [ ] Paste from clipboard — should create a color image entity
- [ ] Save and reload `page.json` — all entities should persist correctly

Closes #10

https://claude.ai/code/session_01FCgdf4GEQZRT5J6MJgLShZ