### PR TITLE
Refactor Entity payload from variant to polymorphic LayerPtr

### DIFF
--- a/src/Page.cpp
+++ b/src/Page.cpp
@@ -20,7 +20,7 @@ int PageModel::addEntity(const T &data, const std::string &name)
     Entity e;
     e.id = id;
     e.name = name.empty() ? "Entity " + std::to_string(id) : name;
-    e.payload = data;
+    e.payload = std::make_shared<T>(data);
     e.localToPage = Mat3();
     e.refreshFilterBase();
     entities[id] = std::move(e);
@@ -43,10 +43,10 @@ int PageModel::addGeneratedEntity(std::unique_ptr<GeneratorBase> gen, Vec2 posit
     // Initialise payload with a default value matching the generator's output kind.
     switch (gen->outputKind())
     {
-    case LayerKind::Bitmap:     e.payload = Bitmap{};     break;
-    case LayerKind::FloatImage: e.payload = FloatImage{}; break;
-    case LayerKind::ColorImage: e.payload = ColorImage{}; break;
-    default:                    e.payload = PathSet{};    break;
+    case LayerKind::Bitmap:     e.payload = std::make_shared<Bitmap>();     break;
+    case LayerKind::FloatImage: e.payload = std::make_shared<FloatImage>(); break;
+    case LayerKind::ColorImage: e.payload = std::make_shared<ColorImage>(); break;
+    default:                    e.payload = std::make_shared<PathSet>();    break;
     }
     e.generator = std::move(gen);
     e.tickGenerator();   // populate payload immediately
@@ -64,7 +64,7 @@ int PageModel::duplicateEntity(int sourceId)
     Entity dst;
     dst.id = page_next_id(entities);
     dst.name = src.name + " Copy";
-    dst.payload = src.payload;        // deep copy PathSet/Bitmap
+    dst.payload = src.baseLayer();     // deep copy via LayerPtr
     dst.payloadVersion = src.payloadVersion;
     dst.localToPage = src.localToPage;
     dst.visible = src.visible;

--- a/src/core/entity.h
+++ b/src/core/entity.h
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <string>
-#include <variant>
 #include "core/Pathset.h"
 #include "core/Bitmap.h"
 #include "core/FloatImage.h"
@@ -10,19 +9,11 @@
 #include "filters/FilterChain.h"
 #include "generators/GeneratorBase.h"
 
-enum class EntityType
-{
-    PathSet,
-    Bitmap,
-    FloatImage,
-    ColorImage
-};
-
 struct Entity
 {
     int id;
     std::string name;
-    std::variant<PathSet, Bitmap, FloatImage, ColorImage> payload;
+    LayerPtr payload;
     uint64_t payloadVersion{1};
     bool visible{true};
     Color color{1.0f, 1.0f, 1.0f, 1.0f};
@@ -30,31 +21,30 @@ struct Entity
     // takes a point from local entity space (mm) to page space (mm)
     Mat3 localToPage;
 
-    EntityType type() const
+    LayerKind type() const
     {
-        if (std::holds_alternative<PathSet>(payload)) return EntityType::PathSet;
-        if (std::holds_alternative<Bitmap>(payload)) return EntityType::Bitmap;
-        if (std::holds_alternative<FloatImage>(payload)) return EntityType::FloatImage;
-        return EntityType::ColorImage;
+        return payload ? payload->kind() : LayerKind::PathSet;
     }
 
     BoundingBox boundsLocal() const
     {
-        if (auto ps = std::get_if<PathSet>(&payload))
+        if (!payload) return BoundingBox{};
+        switch (payload->kind())
         {
+        case LayerKind::PathSet:
+        {
+            auto *ps = asPathSetPtr(payload);
             ps->computeAABB();
             return ps->aabb;
         }
-        if (auto bmp = std::get_if<Bitmap>(&payload))
-        {
-            return bmp->aabb();
+        case LayerKind::Bitmap:
+            return asBitmapConstPtr(payload)->aabb();
+        case LayerKind::FloatImage:
+            return asFloatImageConstPtr(payload)->aabb();
+        case LayerKind::ColorImage:
+            return asColorImageConstPtr(payload)->aabb();
         }
-        if (auto fi = std::get_if<FloatImage>(&payload))
-        {
-            return fi->aabb();
-        }
-        const ColorImage &ci = std::get<ColorImage>(payload);
-        return ci.aabb();
+        return BoundingBox{};
     }
 
     bool contains(const Vec2 &point, float margin_mm = 0) const
@@ -62,14 +52,14 @@ struct Entity
         return boundsLocal().contains(localToPage / point, margin_mm);
     }
 
-    const PathSet *pathset() const { return std::get_if<PathSet>(&payload); }
-    PathSet *pathset() { return std::get_if<PathSet>(&payload); }
-    const Bitmap *bitmap() const { return std::get_if<Bitmap>(&payload); }
-    Bitmap *bitmap() { return std::get_if<Bitmap>(&payload); }
-    const FloatImage *floatImage() const { return std::get_if<FloatImage>(&payload); }
-    FloatImage *floatImage() { return std::get_if<FloatImage>(&payload); }
-    const ColorImage *colorImage() const { return std::get_if<ColorImage>(&payload); }
-    ColorImage *colorImage() { return std::get_if<ColorImage>(&payload); }
+    const PathSet *pathset() const { return asPathSetConstPtr(payload); }
+    PathSet *pathset() { return asPathSetPtr(payload); }
+    const Bitmap *bitmap() const { return asBitmapConstPtr(payload); }
+    Bitmap *bitmap() { return asBitmapPtr(payload); }
+    const FloatImage *floatImage() const { return asFloatImageConstPtr(payload); }
+    FloatImage *floatImage() { return asFloatImagePtr(payload); }
+    const ColorImage *colorImage() const { return asColorImageConstPtr(payload); }
+    ColorImage *colorImage() { return asColorImagePtr(payload); }
 
     // Filter chain: transforms from base payload to display/output layer
     FilterChain filterChain;
@@ -78,17 +68,23 @@ struct Entity
     // Null for entities loaded from file (static payload).
     std::unique_ptr<GeneratorBase> generator;
 
-    // Helper to package current payload into a LayerPtr
+    // Helper to package current payload into a LayerPtr for the filter chain base.
+    // Returns a copy so the filter chain owns its own data.
     LayerPtr baseLayer() const
     {
-        if (auto ps = std::get_if<PathSet>(&payload))
-            return makeLayerFrom(*ps);
-        if (auto bmp = std::get_if<Bitmap>(&payload))
-            return makeLayerFrom(*bmp);
-        if (auto fi = std::get_if<FloatImage>(&payload))
-            return makeLayerFrom(*fi);
-        const ColorImage &ci = std::get<ColorImage>(payload);
-        return makeLayerFrom(ci);
+        if (!payload) return nullptr;
+        switch (payload->kind())
+        {
+        case LayerKind::PathSet:
+            return makeLayerFrom(*asPathSetConstPtr(payload));
+        case LayerKind::Bitmap:
+            return makeLayerFrom(*asBitmapConstPtr(payload));
+        case LayerKind::FloatImage:
+            return makeLayerFrom(*asFloatImageConstPtr(payload));
+        case LayerKind::ColorImage:
+            return makeLayerFrom(*asColorImageConstPtr(payload));
+        }
+        return nullptr;
     }
 
     void refreshFilterBase()
@@ -136,20 +132,11 @@ struct Entity
 private:
     uint64_t m_lastGenVer{0};
 
-    // Unpack a completed LayerPtr into the payload variant and refresh the
-    // filter chain. Used by both the sync and async paths.
+    // Transfer a completed LayerPtr into the payload and refresh the filter chain.
     void applyGeneratorResult(const LayerPtr &out)
     {
         if (!out) return;
-        if (isPathSetLayer(out))
-            payload = *asPathSetPtr(out);
-        else if (isBitmapLayer(out))
-            payload = *asBitmapPtr(out);
-        else if (isFloatImageLayer(out))
-            payload = *asFloatImagePtr(out);
-        else if (isColorImageLayer(out))
-            payload = *asColorImagePtr(out);
-
+        payload = out;
         payloadVersion++;
         refreshFilterBase();
     }

--- a/src/plotters/PlotSpooler.cpp
+++ b/src/plotters/PlotSpooler.cpp
@@ -399,7 +399,7 @@ bool PlotSpooler::prepareJob(const PageModel &page, bool liftPen)
         if (m_onlyEntityId.has_value() && kv.first != *m_onlyEntityId)
             continue;
         const PathSet *ps = nullptr;
-        if (e.type() == EntityType::PathSet)
+        if (e.type() == LayerKind::PathSet)
         {
             ps = e.pathset();
         }

--- a/src/utils/Serialization.cpp
+++ b/src/utils/Serialization.cpp
@@ -328,37 +328,37 @@ static void from_json(const json &j, Entity &e)
             }
         }
 
-        // Initialise payload variant to match generator output kind
+        // Initialise payload to match generator output kind
         std::string type = j.value("type", std::string("pathset"));
-        if (type == "bitmap")           e.payload = Bitmap{};
-        else if (type == "floatimage")  e.payload = FloatImage{};
-        else if (type == "colorimage")  e.payload = ColorImage{};
-        else                            e.payload = PathSet{};
+        if (type == "bitmap")           e.payload = std::make_shared<Bitmap>();
+        else if (type == "floatimage")  e.payload = std::make_shared<FloatImage>();
+        else if (type == "colorimage")  e.payload = std::make_shared<ColorImage>();
+        else                            e.payload = std::make_shared<PathSet>();
         // tickGenerator() will be called in loadPageModel after refreshFilterBase()
     }
     else
     {
-        // Static entity: deserialize payload as before
+        // Static entity: deserialize payload
         std::string type = j.value("type", std::string("pathset"));
         if (type == "bitmap" && j.contains("bitmap"))
         {
-            e.payload = j.at("bitmap").get<Bitmap>();
+            e.payload = std::make_shared<Bitmap>(j.at("bitmap").get<Bitmap>());
         }
         else if (type == "colorimage" && j.contains("colorimage"))
         {
-            e.payload = j.at("colorimage").get<ColorImage>();
+            e.payload = std::make_shared<ColorImage>(j.at("colorimage").get<ColorImage>());
         }
         else if (type == "floatimage" && j.contains("floatimage"))
         {
-            e.payload = j.at("floatimage").get<FloatImage>();
+            e.payload = std::make_shared<FloatImage>(j.at("floatimage").get<FloatImage>());
         }
         else
         {
             // Default to pathset for backward compatibility
             if (j.contains("pathset"))
-                e.payload = j.at("pathset").get<PathSet>();
+                e.payload = std::make_shared<PathSet>(j.at("pathset").get<PathSet>());
             else
-                e.payload = PathSet{};
+                e.payload = std::make_shared<PathSet>();
         }
     }
 }


### PR DESCRIPTION
## Summary
Refactored the `Entity` struct to use a polymorphic `LayerPtr` (shared pointer to a base `Layer` class) instead of a `std::variant` for storing different layer types (PathSet, Bitmap, FloatImage, ColorImage). This simplifies type handling and aligns the entity payload with the existing filter chain architecture.

## Key Changes

- **Removed variant-based payload**: Replaced `std::variant<PathSet, Bitmap, FloatImage, ColorImage>` with `LayerPtr payload` in the Entity struct
- **Removed EntityType enum**: Replaced with `LayerKind` enum which is already used by the filter chain system
- **Updated type() method**: Now delegates to `payload->kind()` instead of checking variant alternatives
- **Refactored type-checking logic**: Converted `std::get_if<T>()` calls to use polymorphic cast functions (`asPathSetPtr()`, `asBitmapPtr()`, etc.)
- **Simplified boundsLocal()**: Changed from variant pattern matching to a switch statement on `payload->kind()`
- **Updated applyGeneratorResult()**: Now directly assigns the `LayerPtr` instead of unpacking and re-wrapping it
- **Updated serialization**: Modified `Serialization.cpp` to wrap deserialized objects in `std::make_shared<T>()` when assigning to payload
- **Updated entity creation**: Modified `Page.cpp` to wrap data in shared pointers when creating entities
- **Fixed entity duplication**: Changed `duplicateEntity()` to use `baseLayer()` for proper deep copying via LayerPtr

## Implementation Details

- The change maintains backward compatibility with existing serialization by preserving the type field in JSON
- The `baseLayer()` method now returns a copy of the payload as a LayerPtr, which is used for filter chain processing
- All accessor methods (`pathset()`, `bitmap()`, etc.) now use the polymorphic cast functions instead of variant accessors
- The refactoring reduces code duplication and makes the codebase more consistent with the filter chain's layer abstraction

https://claude.ai/code/session_01TqkhhWbTJ2F6exNzqySf6R