### PR TITLE
Refactor Entity payload to use LayerPtr instead of variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,3 +77,12 @@ target_include_directories(motion_planner_tests PRIVATE src)
 target_link_libraries(motion_planner_tests PRIVATE GTest::gtest GTest::gtest_main)
 
 add_test(NAME motion_planner COMMAND motion_planner_tests)
+
+add_executable(filter_tests
+  tests/test_filters.cpp
+)
+
+target_include_directories(filter_tests PRIVATE src)
+target_link_libraries(filter_tests PRIVATE GTest::gtest GTest::gtest_main glog::glog fmt::fmt)
+
+add_test(NAME filters COMMAND filter_tests)

--- a/src/Page.cpp
+++ b/src/Page.cpp
@@ -20,7 +20,7 @@ int PageModel::addEntity(const T &data, const std::string &name)
     Entity e;
     e.id = id;
     e.name = name.empty() ? "Entity " + std::to_string(id) : name;
-    e.payload = data;
+    e.payload = std::make_shared<T>(data);
     e.localToPage = Mat3();
     e.refreshFilterBase();
     entities[id] = std::move(e);
@@ -43,10 +43,10 @@ int PageModel::addGeneratedEntity(std::unique_ptr<GeneratorBase> gen, Vec2 posit
     // Initialise payload with a default value matching the generator's output kind.
     switch (gen->outputKind())
     {
-    case LayerKind::Bitmap:     e.payload = Bitmap{};     break;
-    case LayerKind::FloatImage: e.payload = FloatImage{}; break;
-    case LayerKind::ColorImage: e.payload = ColorImage{}; break;
-    default:                    e.payload = PathSet{};    break;
+    case LayerKind::Bitmap:     e.payload = std::make_shared<Bitmap>();     break;
+    case LayerKind::FloatImage: e.payload = std::make_shared<FloatImage>(); break;
+    case LayerKind::ColorImage: e.payload = std::make_shared<ColorImage>(); break;
+    default:                    e.payload = std::make_shared<PathSet>();    break;
     }
     e.generator = std::move(gen);
     e.tickGenerator();   // populate payload immediately
@@ -64,7 +64,17 @@ int PageModel::duplicateEntity(int sourceId)
     Entity dst;
     dst.id = page_next_id(entities);
     dst.name = src.name + " Copy";
-    dst.payload = src.payload;        // deep copy PathSet/Bitmap
+    // Deep copy payload via LayerKind dispatch
+    if (src.payload)
+    {
+        switch (src.payload->kind())
+        {
+        case LayerKind::PathSet:    dst.payload = makeLayerFrom(*asPathSetConstPtr(src.payload));    break;
+        case LayerKind::Bitmap:     dst.payload = makeLayerFrom(*asBitmapConstPtr(src.payload));     break;
+        case LayerKind::FloatImage: dst.payload = makeLayerFrom(*asFloatImageConstPtr(src.payload)); break;
+        case LayerKind::ColorImage: dst.payload = makeLayerFrom(*asColorImageConstPtr(src.payload)); break;
+        }
+    }
     dst.payloadVersion = src.payloadVersion;
     dst.localToPage = src.localToPage;
     dst.visible = src.visible;

--- a/src/core/entity.h
+++ b/src/core/entity.h
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <string>
-#include <variant>
 #include "core/Pathset.h"
 #include "core/Bitmap.h"
 #include "core/FloatImage.h"
@@ -10,19 +9,11 @@
 #include "filters/FilterChain.h"
 #include "generators/GeneratorBase.h"
 
-enum class EntityType
-{
-    PathSet,
-    Bitmap,
-    FloatImage,
-    ColorImage
-};
-
 struct Entity
 {
     int id;
     std::string name;
-    std::variant<PathSet, Bitmap, FloatImage, ColorImage> payload;
+    LayerPtr payload;
     uint64_t payloadVersion{1};
     bool visible{true};
     Color color{1.0f, 1.0f, 1.0f, 1.0f};
@@ -30,31 +21,30 @@ struct Entity
     // takes a point from local entity space (mm) to page space (mm)
     Mat3 localToPage;
 
-    EntityType type() const
+    LayerKind type() const
     {
-        if (std::holds_alternative<PathSet>(payload)) return EntityType::PathSet;
-        if (std::holds_alternative<Bitmap>(payload)) return EntityType::Bitmap;
-        if (std::holds_alternative<FloatImage>(payload)) return EntityType::FloatImage;
-        return EntityType::ColorImage;
+        return payload ? payload->kind() : LayerKind::PathSet;
     }
 
     BoundingBox boundsLocal() const
     {
-        if (auto ps = std::get_if<PathSet>(&payload))
+        if (!payload) return BoundingBox{};
+        switch (payload->kind())
         {
+        case LayerKind::PathSet:
+        {
+            auto *ps = asPathSetPtr(payload);
             ps->computeAABB();
             return ps->aabb;
         }
-        if (auto bmp = std::get_if<Bitmap>(&payload))
-        {
-            return bmp->aabb();
+        case LayerKind::Bitmap:
+            return asBitmapPtr(payload)->aabb();
+        case LayerKind::FloatImage:
+            return asFloatImagePtr(payload)->aabb();
+        case LayerKind::ColorImage:
+            return asColorImagePtr(payload)->aabb();
         }
-        if (auto fi = std::get_if<FloatImage>(&payload))
-        {
-            return fi->aabb();
-        }
-        const ColorImage &ci = std::get<ColorImage>(payload);
-        return ci.aabb();
+        return BoundingBox{};
     }
 
     bool contains(const Vec2 &point, float margin_mm = 0) const
@@ -62,14 +52,14 @@ struct Entity
         return boundsLocal().contains(localToPage / point, margin_mm);
     }
 
-    const PathSet *pathset() const { return std::get_if<PathSet>(&payload); }
-    PathSet *pathset() { return std::get_if<PathSet>(&payload); }
-    const Bitmap *bitmap() const { return std::get_if<Bitmap>(&payload); }
-    Bitmap *bitmap() { return std::get_if<Bitmap>(&payload); }
-    const FloatImage *floatImage() const { return std::get_if<FloatImage>(&payload); }
-    FloatImage *floatImage() { return std::get_if<FloatImage>(&payload); }
-    const ColorImage *colorImage() const { return std::get_if<ColorImage>(&payload); }
-    ColorImage *colorImage() { return std::get_if<ColorImage>(&payload); }
+    const PathSet *pathset() const { return asPathSetConstPtr(payload); }
+    PathSet *pathset() { return asPathSetPtr(payload); }
+    const Bitmap *bitmap() const { return asBitmapConstPtr(payload); }
+    Bitmap *bitmap() { return asBitmapPtr(payload); }
+    const FloatImage *floatImage() const { return asFloatImageConstPtr(payload); }
+    FloatImage *floatImage() { return asFloatImagePtr(payload); }
+    const ColorImage *colorImage() const { return asColorImageConstPtr(payload); }
+    ColorImage *colorImage() { return asColorImagePtr(payload); }
 
     // Filter chain: transforms from base payload to display/output layer
     FilterChain filterChain;
@@ -78,17 +68,19 @@ struct Entity
     // Null for entities loaded from file (static payload).
     std::unique_ptr<GeneratorBase> generator;
 
-    // Helper to package current payload into a LayerPtr
+    // Helper to package current payload into a LayerPtr for the filter chain base.
+    // Returns a copy so the filter chain has its own shared_ptr.
     LayerPtr baseLayer() const
     {
-        if (auto ps = std::get_if<PathSet>(&payload))
-            return makeLayerFrom(*ps);
-        if (auto bmp = std::get_if<Bitmap>(&payload))
-            return makeLayerFrom(*bmp);
-        if (auto fi = std::get_if<FloatImage>(&payload))
-            return makeLayerFrom(*fi);
-        const ColorImage &ci = std::get<ColorImage>(payload);
-        return makeLayerFrom(ci);
+        if (!payload) return nullptr;
+        switch (payload->kind())
+        {
+        case LayerKind::PathSet:    return makeLayerFrom(*asPathSetConstPtr(payload));
+        case LayerKind::Bitmap:     return makeLayerFrom(*asBitmapConstPtr(payload));
+        case LayerKind::FloatImage: return makeLayerFrom(*asFloatImageConstPtr(payload));
+        case LayerKind::ColorImage: return makeLayerFrom(*asColorImageConstPtr(payload));
+        }
+        return nullptr;
     }
 
     void refreshFilterBase()
@@ -136,20 +128,11 @@ struct Entity
 private:
     uint64_t m_lastGenVer{0};
 
-    // Unpack a completed LayerPtr into the payload variant and refresh the
-    // filter chain. Used by both the sync and async paths.
+    // Transfer a completed LayerPtr into the payload and refresh the filter chain.
     void applyGeneratorResult(const LayerPtr &out)
     {
         if (!out) return;
-        if (isPathSetLayer(out))
-            payload = *asPathSetPtr(out);
-        else if (isBitmapLayer(out))
-            payload = *asBitmapPtr(out);
-        else if (isFloatImageLayer(out))
-            payload = *asFloatImagePtr(out);
-        else if (isColorImageLayer(out))
-            payload = *asColorImagePtr(out);
-
+        payload = out;
         payloadVersion++;
         refreshFilterBase();
     }

--- a/src/plotters/PlotSpooler.cpp
+++ b/src/plotters/PlotSpooler.cpp
@@ -399,7 +399,7 @@ bool PlotSpooler::prepareJob(const PageModel &page, bool liftPen)
         if (m_onlyEntityId.has_value() && kv.first != *m_onlyEntityId)
             continue;
         const PathSet *ps = nullptr;
-        if (e.type() == EntityType::PathSet)
+        if (e.type() == LayerKind::PathSet)
         {
             ps = e.pathset();
         }

--- a/src/utils/Serialization.cpp
+++ b/src/utils/Serialization.cpp
@@ -330,10 +330,10 @@ static void from_json(const json &j, Entity &e)
 
         // Initialise payload variant to match generator output kind
         std::string type = j.value("type", std::string("pathset"));
-        if (type == "bitmap")           e.payload = Bitmap{};
-        else if (type == "floatimage")  e.payload = FloatImage{};
-        else if (type == "colorimage")  e.payload = ColorImage{};
-        else                            e.payload = PathSet{};
+        if (type == "bitmap")           e.payload = std::make_shared<Bitmap>();
+        else if (type == "floatimage")  e.payload = std::make_shared<FloatImage>();
+        else if (type == "colorimage")  e.payload = std::make_shared<ColorImage>();
+        else                            e.payload = std::make_shared<PathSet>();
         // tickGenerator() will be called in loadPageModel after refreshFilterBase()
     }
     else
@@ -342,23 +342,23 @@ static void from_json(const json &j, Entity &e)
         std::string type = j.value("type", std::string("pathset"));
         if (type == "bitmap" && j.contains("bitmap"))
         {
-            e.payload = j.at("bitmap").get<Bitmap>();
+            e.payload = std::make_shared<Bitmap>(j.at("bitmap").get<Bitmap>());
         }
         else if (type == "colorimage" && j.contains("colorimage"))
         {
-            e.payload = j.at("colorimage").get<ColorImage>();
+            e.payload = std::make_shared<ColorImage>(j.at("colorimage").get<ColorImage>());
         }
         else if (type == "floatimage" && j.contains("floatimage"))
         {
-            e.payload = j.at("floatimage").get<FloatImage>();
+            e.payload = std::make_shared<FloatImage>(j.at("floatimage").get<FloatImage>());
         }
         else
         {
             // Default to pathset for backward compatibility
             if (j.contains("pathset"))
-                e.payload = j.at("pathset").get<PathSet>();
+                e.payload = std::make_shared<PathSet>(j.at("pathset").get<PathSet>());
             else
-                e.payload = PathSet{};
+                e.payload = std::make_shared<PathSet>();
         }
     }
 }

--- a/tests/test_filters.cpp
+++ b/tests/test_filters.cpp
@@ -1,0 +1,440 @@
+#include <gtest/gtest.h>
+
+#include "../src/core/Bitmap.h"
+#include "../src/core/Pathset.h"
+#include "../src/core/FloatImage.h"
+#include "../src/filters/Filter.h"
+#include "../src/filters/bitmap/ThresholdFilter.h"
+#include "../src/filters/bitmap/BlurFilter.h"
+#include "../src/filters/bitmap/ErodeDilateFilter.h"
+#include "../src/filters/bitmap/RotateFilter.h"
+#include "../src/filters/bitmap/TraceFilter.h"
+#include "../src/filters/bitmap/BitmapToFloatFilter.h"
+#include "../src/filters/bitmap/LineHatchFilter.h"
+#include "../src/filters/pathset/SimplifyFilter.h"
+#include "../src/filters/pathset/SmoothFilter.h"
+#include "../src/filters/pathset/OptimizePathsFilter.h"
+
+// Helper: create a grayscale bitmap with a uniform value
+static Bitmap makeUniformBitmap(int w, int h, uint8_t value, float pixel_size_mm = 0.1f)
+{
+	Bitmap b;
+	b.width_px = w;
+	b.height_px = h;
+	b.pixel_size_mm = pixel_size_mm;
+	b.pixels.assign(static_cast<size_t>(w * h), value);
+	return b;
+}
+
+// Helper: create a bitmap with a horizontal gradient (0 on left, 255 on right)
+static Bitmap makeGradientBitmap(int w, int h, float pixel_size_mm = 0.1f)
+{
+	Bitmap b;
+	b.width_px = w;
+	b.height_px = h;
+	b.pixel_size_mm = pixel_size_mm;
+	b.pixels.resize(static_cast<size_t>(w * h));
+	for (int y = 0; y < h; ++y)
+		for (int x = 0; x < w; ++x)
+			b.pixels[static_cast<size_t>(y * w + x)] = static_cast<uint8_t>(255 * x / (w - 1));
+	return b;
+}
+
+// Helper: create a simple PathSet with a few paths
+static PathSet makeSimplePathSet()
+{
+	PathSet ps;
+	Path p;
+	p.points = {{0, 0}, {10, 0}, {10, 10}, {0, 10}};
+	p.closed = true;
+	ps.paths.push_back(p);
+
+	Path p2;
+	p2.points = {{20, 20}, {30, 20}, {30, 30}};
+	p2.closed = false;
+	ps.paths.push_back(p2);
+	return ps;
+}
+
+// Helper: apply a filter and return the output LayerPtr
+static LayerPtr applyFilter(FilterBase &filter, const LayerPtr &input)
+{
+	LayerPtr output;
+	filter.apply(input, output);
+	return output;
+}
+
+// ---------------------------------------------------------------------------
+// ThresholdFilter tests
+// ---------------------------------------------------------------------------
+
+TEST(ThresholdFilter, PixelsBelowMinBecomeBlack)
+{
+	ThresholdFilter f;
+	f.setParameter("min", 100.0f);
+	f.setParameter("max", 200.0f);
+
+	auto input = makeUniformBitmap(10, 10, 50); // all pixels below min
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isBitmapLayer(out));
+	const Bitmap &result = *asBitmapPtr(out);
+	EXPECT_EQ(result.width_px, 10);
+	EXPECT_EQ(result.height_px, 10);
+	for (auto px : result.pixels)
+		EXPECT_EQ(px, 0) << "Pixels below min threshold should be 0";
+}
+
+TEST(ThresholdFilter, PixelsInRangeBecomeWhite)
+{
+	ThresholdFilter f;
+	f.setParameter("min", 100.0f);
+	f.setParameter("max", 200.0f);
+
+	auto input = makeUniformBitmap(10, 10, 150); // all pixels in range
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isBitmapLayer(out));
+	const Bitmap &result = *asBitmapPtr(out);
+	for (auto px : result.pixels)
+		EXPECT_EQ(px, 255) << "Pixels in [min, max] range should be 255";
+}
+
+TEST(ThresholdFilter, PixelsAboveMaxBecomeBlack)
+{
+	ThresholdFilter f;
+	f.setParameter("min", 50.0f);
+	f.setParameter("max", 100.0f);
+
+	auto input = makeUniformBitmap(10, 10, 200); // all pixels above max
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isBitmapLayer(out));
+	const Bitmap &result = *asBitmapPtr(out);
+	for (auto px : result.pixels)
+		EXPECT_EQ(px, 0) << "Pixels above max threshold should be 0";
+}
+
+TEST(ThresholdFilter, PreservesDimensions)
+{
+	ThresholdFilter f;
+	auto input = makeUniformBitmap(37, 19, 128);
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isBitmapLayer(out));
+	const Bitmap &result = *asBitmapPtr(out);
+	EXPECT_EQ(result.width_px, 37);
+	EXPECT_EQ(result.height_px, 19);
+	EXPECT_EQ(result.pixel_size_mm, input.pixel_size_mm);
+}
+
+// ---------------------------------------------------------------------------
+// BlurFilter tests
+// ---------------------------------------------------------------------------
+
+TEST(BlurFilter, UniformImageUnchanged)
+{
+	BlurFilter f;
+	f.setParameter("radius", 3.0f);
+
+	auto input = makeUniformBitmap(20, 20, 128);
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isBitmapLayer(out));
+	const Bitmap &result = *asBitmapPtr(out);
+	for (auto px : result.pixels)
+		EXPECT_NEAR(px, 128, 1) << "Blurring a uniform image should not change pixel values";
+}
+
+TEST(BlurFilter, ReducesContrast)
+{
+	BlurFilter f;
+	f.setParameter("radius", 2.0f);
+
+	// Checkerboard pattern: alternating 0 and 255
+	Bitmap input;
+	input.width_px = 20;
+	input.height_px = 20;
+	input.pixel_size_mm = 0.1f;
+	input.pixels.resize(400);
+	for (int y = 0; y < 20; ++y)
+		for (int x = 0; x < 20; ++x)
+			input.pixels[static_cast<size_t>(y * 20 + x)] = ((x + y) % 2 == 0) ? 255 : 0;
+
+	auto out = applyFilter(f, makeLayerFrom(input));
+	ASSERT_TRUE(isBitmapLayer(out));
+	const Bitmap &result = *asBitmapPtr(out);
+
+	// After blurring, no pixel should be at the extremes
+	bool allMiddle = true;
+	for (auto px : result.pixels)
+	{
+		if (px == 0 || px == 255)
+			allMiddle = false;
+	}
+	EXPECT_TRUE(allMiddle) << "Blurring a checkerboard should move all pixels away from extremes";
+}
+
+TEST(BlurFilter, PreservesDimensions)
+{
+	BlurFilter f;
+	f.setParameter("radius", 1.0f);
+
+	auto input = makeGradientBitmap(50, 30);
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isBitmapLayer(out));
+	const Bitmap &result = *asBitmapPtr(out);
+	EXPECT_EQ(result.width_px, 50);
+	EXPECT_EQ(result.height_px, 30);
+}
+
+// ---------------------------------------------------------------------------
+// ErodeDilateFilter tests
+// ---------------------------------------------------------------------------
+
+TEST(ErodeDilateFilter, ErodeShrinksWhiteRegion)
+{
+	ErodeDilateFilter f;
+	f.setParameter("operation", 0.0f); // Erode
+	f.setParameter("iterations", 1.0f);
+
+	// White square on black background
+	auto input = makeUniformBitmap(20, 20, 0);
+	for (int y = 5; y < 15; ++y)
+		for (int x = 5; x < 15; ++x)
+			input.pixels[static_cast<size_t>(y * 20 + x)] = 255;
+
+	auto out = applyFilter(f, makeLayerFrom(input));
+	ASSERT_TRUE(isBitmapLayer(out));
+	const Bitmap &result = *asBitmapPtr(out);
+
+	// After erosion, the border pixels of the white square should be gone
+	EXPECT_EQ(result.pixels[5 * 20 + 5], 0) << "Corner pixel should be eroded";
+	// Center should still be white
+	EXPECT_EQ(result.pixels[10 * 20 + 10], 255) << "Center pixel should survive erosion";
+}
+
+TEST(ErodeDilateFilter, DilateExpandsWhiteRegion)
+{
+	ErodeDilateFilter f;
+	f.setParameter("operation", 1.0f); // Dilate
+	f.setParameter("iterations", 1.0f);
+
+	// Single white pixel in center of black image
+	auto input = makeUniformBitmap(20, 20, 0);
+	input.pixels[10 * 20 + 10] = 255;
+
+	auto out = applyFilter(f, makeLayerFrom(input));
+	ASSERT_TRUE(isBitmapLayer(out));
+	const Bitmap &result = *asBitmapPtr(out);
+
+	// Neighbors of center should now be white
+	EXPECT_EQ(result.pixels[10 * 20 + 10], 255) << "Center should remain white";
+	EXPECT_EQ(result.pixels[9 * 20 + 10], 255) << "Pixel above should be dilated";
+	EXPECT_EQ(result.pixels[11 * 20 + 10], 255) << "Pixel below should be dilated";
+	EXPECT_EQ(result.pixels[10 * 20 + 9], 255) << "Pixel left should be dilated";
+	EXPECT_EQ(result.pixels[10 * 20 + 11], 255) << "Pixel right should be dilated";
+}
+
+// ---------------------------------------------------------------------------
+// TraceFilter tests
+// ---------------------------------------------------------------------------
+
+TEST(TraceFilter, EmptyImageProducesNoPaths)
+{
+	TraceFilter f;
+	f.setParameter("threshold", 128.0f);
+
+	// All-black image: nothing above threshold
+	auto input = makeUniformBitmap(20, 20, 0);
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isPathSetLayer(out));
+	const PathSet &result = *asPathSetPtr(out);
+	EXPECT_TRUE(result.paths.empty()) << "All-black image should produce no traced paths";
+}
+
+TEST(TraceFilter, WhiteImageProducesPaths)
+{
+	TraceFilter f;
+	f.setParameter("threshold", 128.0f);
+
+	// All-white image: all above threshold
+	auto input = makeUniformBitmap(20, 20, 255);
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isPathSetLayer(out));
+	const PathSet &result = *asPathSetPtr(out);
+	EXPECT_FALSE(result.paths.empty()) << "All-white image should produce traced paths";
+}
+
+TEST(TraceFilter, OutputIsPathSet)
+{
+	TraceFilter f;
+	auto input = makeGradientBitmap(30, 30);
+	auto out = applyFilter(f, makeLayerFrom(input));
+	EXPECT_TRUE(isPathSetLayer(out));
+}
+
+// ---------------------------------------------------------------------------
+// SimplifyFilter tests
+// ---------------------------------------------------------------------------
+
+TEST(SimplifyFilter, ZeroTolerancePreservesPoints)
+{
+	SimplifyFilter f;
+	f.setParameter("toleranceMm", 0.0f);
+	f.setParameter("minPathLengthMm", 0.0f);
+
+	auto input = makeSimplePathSet();
+	size_t totalPointsBefore = 0;
+	for (const auto &p : input.paths)
+		totalPointsBefore += p.points.size();
+
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isPathSetLayer(out));
+	const PathSet &result = *asPathSetPtr(out);
+	size_t totalPointsAfter = 0;
+	for (const auto &p : result.paths)
+		totalPointsAfter += p.points.size();
+
+	EXPECT_EQ(result.paths.size(), input.paths.size());
+	EXPECT_EQ(totalPointsAfter, totalPointsBefore)
+		<< "Zero tolerance should preserve all points";
+}
+
+TEST(SimplifyFilter, HighToleranceReducesPoints)
+{
+	SimplifyFilter f;
+	f.setParameter("toleranceMm", 1.0f);
+	f.setParameter("minPathLengthMm", 0.0f);
+
+	// Create a path with many collinear-ish points
+	PathSet input;
+	Path p;
+	for (int i = 0; i <= 100; ++i)
+	{
+		float x = static_cast<float>(i) * 0.5f;
+		float y = x + 0.01f * (i % 3); // tiny wobble
+		p.points.push_back({x, y});
+	}
+	p.closed = false;
+	input.paths.push_back(p);
+
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isPathSetLayer(out));
+	const PathSet &result = *asPathSetPtr(out);
+	ASSERT_EQ(result.paths.size(), 1u);
+	EXPECT_LT(result.paths[0].points.size(), p.points.size())
+		<< "High tolerance should reduce point count on nearly-collinear path";
+}
+
+TEST(SimplifyFilter, MinPathLengthRemovesShortPaths)
+{
+	SimplifyFilter f;
+	f.setParameter("toleranceMm", 0.0f);
+	f.setParameter("minPathLengthMm", 5.0f);
+
+	PathSet input;
+	// Short path (length ~1.4mm)
+	Path short_p;
+	short_p.points = {{0, 0}, {1, 1}};
+	short_p.closed = false;
+	input.paths.push_back(short_p);
+
+	// Long path (length ~30mm)
+	Path long_p;
+	long_p.points = {{0, 0}, {10, 0}, {10, 10}, {0, 10}};
+	long_p.closed = false;
+	input.paths.push_back(long_p);
+
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isPathSetLayer(out));
+	const PathSet &result = *asPathSetPtr(out);
+	EXPECT_EQ(result.paths.size(), 1u)
+		<< "Short path should be removed by minPathLengthMm filter";
+}
+
+// ---------------------------------------------------------------------------
+// SmoothFilter tests
+// ---------------------------------------------------------------------------
+
+TEST(SmoothFilter, ZeroIterationsPreservesPaths)
+{
+	SmoothFilter f;
+	f.setParameter("iterations", 0.0f);
+
+	auto input = makeSimplePathSet();
+	auto out = applyFilter(f, makeLayerFrom(input));
+
+	ASSERT_TRUE(isPathSetLayer(out));
+	const PathSet &result = *asPathSetPtr(out);
+	ASSERT_EQ(result.paths.size(), input.paths.size());
+	for (size_t i = 0; i < input.paths.size(); ++i)
+	{
+		ASSERT_EQ(result.paths[i].points.size(), input.paths[i].points.size());
+		for (size_t j = 0; j < input.paths[i].points.size(); ++j)
+		{
+			EXPECT_FLOAT_EQ(result.paths[i].points[j].x, input.paths[i].points[j].x);
+			EXPECT_FLOAT_EQ(result.paths[i].points[j].y, input.paths[i].points[j].y);
+		}
+	}
+}
+
+TEST(SmoothFilter, SmoothingReducesSharpCorners)
+{
+	SmoothFilter f;
+	f.setParameter("iterations", 5.0f);
+
+	// Zigzag path with sharp corners
+	PathSet input;
+	Path p;
+	p.points = {{0, 0}, {5, 10}, {10, 0}, {15, 10}, {20, 0}};
+	p.closed = false;
+	input.paths.push_back(p);
+
+	auto out = applyFilter(f, makeLayerFrom(input));
+	ASSERT_TRUE(isPathSetLayer(out));
+	const PathSet &result = *asPathSetPtr(out);
+	ASSERT_EQ(result.paths.size(), 1u);
+
+	// After smoothing, the peak at (5,10) should be less extreme
+	// (moved toward the average of its neighbors)
+	EXPECT_LT(result.paths[0].points[1].y, 10.0f)
+		<< "Smoothing should reduce sharp peaks";
+}
+
+// ---------------------------------------------------------------------------
+// TODO: Additional filter tests to implement
+// ---------------------------------------------------------------------------
+
+// TODO: RotateFilter - verify 0 degree rotation preserves image,
+//       180 degree rotation flips pixels, dimensions change for non-square
+
+// TODO: BitmapToFloatFilter - verify output is FloatImage type,
+//       dimensions preserved, SDF values have correct sign
+
+// TODO: LineHatchFilter - verify output is PathSet, non-empty for
+//       white image, empty for black image, angle parameter affects direction
+
+// TODO: OptimizePathsFilter - verify reorder flag changes path order,
+//       merge flag joins nearby endpoints
+
+// TODO: CurlNoiseFilter - verify output PathSet has same path count,
+//       points are displaced from original positions
+
+// TODO: LaplacianSmoothFilter - similar to SmoothFilter but different algorithm
+
+// TODO: SkeletonizeFilter - verify thin white lines remain after skeletonization
+
+// TODO: CannyFilter - verify edge detection on gradient image produces edges
+
+// TODO: ClaheFilter - verify contrast-limited histogram equalization
+//       produces full-range output
+
+// TODO: FilterChain integration test - chain multiple filters and verify
+//       cache invalidation when parameters change


### PR DESCRIPTION
## Summary
This PR refactors the `Entity` struct to store its payload as a `LayerPtr` (shared pointer to a polymorphic `Layer` base class) instead of a `std::variant`. This change simplifies the codebase by eliminating variant-based type checking and dispatching in favor of virtual method calls and helper functions.

## Key Changes

- **Entity payload storage**: Changed `Entity::payload` from `std::variant<PathSet, Bitmap, FloatImage, ColorImage>` to `LayerPtr`, eliminating the need for `EntityType` enum
- **Type checking**: Replaced `std::get_if<T>()` calls with helper functions (`asPathSetPtr()`, `asBitmapPtr()`, etc.) that work with the `LayerPtr` abstraction
- **Initialization**: Updated all payload initialization to use `std::make_shared<T>()` to create shared pointers
- **Deep copying**: Modified entity duplication to use `makeLayerFrom()` helper for proper deep copying through the layer abstraction
- **Serialization**: Updated JSON deserialization to construct shared pointers when loading entities from files
- **Filter tests**: Added comprehensive test suite (`tests/test_filters.cpp`) with 440 lines covering:
  - ThresholdFilter, BlurFilter, ErodeDilateFilter, TraceFilter
  - SimplifyFilter, SmoothFilter
  - Helper functions for creating test bitmaps and pathsets
  - Placeholder TODOs for additional filter tests

## Implementation Details

- The `Entity::type()` method now calls `payload->kind()` on the `LayerPtr` instead of checking variant alternatives
- `Entity::boundsLocal()` uses a switch statement on `payload->kind()` with the helper accessor functions
- `Entity::baseLayer()` creates a new `LayerPtr` copy of the current payload for the filter chain
- All payload access patterns maintain backward compatibility through the helper functions
- CMakeLists.txt updated to build and run the new filter test executable

https://claude.ai/code/session_0178ykuZnBWxTqkaxyPxW2PQ