### PR TITLE
Refactor renderer state into RenderSettings struct

### DIFF
--- a/src/screens/MainScreen.cpp
+++ b/src/screens/MainScreen.cpp
@@ -17,7 +17,8 @@ void MainScreen::onAttach(App &app)
 
     m_app = &app;
     std::string err;
-    if (!serialization::loadProject(m_page, m_camera, m_renderer, m_plotter.config(), m_projectPath, &err))
+    serialization::RenderSettings rs;
+    if (!serialization::loadProject(m_page, m_camera, rs, m_plotter.config(), m_projectPath, &err))
     {
         if (!err.empty())
         {
@@ -30,6 +31,8 @@ void MainScreen::onAttach(App &app)
     }
     else
     {
+        m_renderer.setLineWidth(rs.lineWidth);
+        m_renderer.setNodeDiameterPx(rs.nodeDiameter);
         // Sync AxiDraw state from loaded plotter config
         m_plotter.syncStateFromConfig();
     }
@@ -120,7 +123,8 @@ void MainScreen::onDetach()
     std::string err;
     // Keep pen positions in sync with the last known AxiDraw state
     m_plotter.syncConfigFromState();
-    if (!serialization::saveProject(m_page, m_camera, m_renderer, m_plotter.config(), m_projectPath, &err))
+    serialization::RenderSettings rs{m_renderer.lineWidth(), m_renderer.nodeDiameterPx()};
+    if (!serialization::saveProject(m_page, m_camera, rs, m_plotter.config(), m_projectPath, &err))
     {
         LOG(ERROR) << "Failed to save page.json: " << err;
     }

--- a/src/utils/Serialization.cpp
+++ b/src/utils/Serialization.cpp
@@ -17,7 +17,6 @@
 #include "generators/GeneratorRegistry.h"
 
 #include "Camera.h"
-#include "Renderer.h"
 #include "utils/ImageCompression.h"
 
 
@@ -515,7 +514,7 @@ namespace serialization
         }
     }
 
-    bool saveProject(const PageModel &model, const Camera &camera, const Renderer &renderer,
+    bool saveProject(const PageModel &model, const Camera &camera, const RenderSettings &render,
                      const PlotterConfig &plotter,
                      const std::string &filePath, std::string *errorOut)
     {
@@ -544,10 +543,10 @@ namespace serialization
                 {"zoom", camera.zoom()}
             };
 
-            // Renderer state
+            // Render settings
             j["render"] = json{
-                {"line_width", renderer.lineWidth()},
-                {"node_diameter_px", renderer.nodeDiameterPx()}
+                {"line_width", render.lineWidth},
+                {"node_diameter_px", render.nodeDiameter}
             };
 
             // Plotter config
@@ -582,7 +581,7 @@ namespace serialization
         }
     }
 
-    bool loadProject(PageModel &model, Camera &camera, Renderer &renderer,
+    bool loadProject(PageModel &model, Camera &camera, RenderSettings &render,
                      PlotterConfig &plotter,
                      const std::string &filePath, std::string *errorOut)
     {
@@ -668,13 +667,11 @@ namespace serialization
                 camera.setCenterAndZoom(center, zoom);
             }
 
-            // Optional renderer
+            // Optional render settings
             if (j.contains("render"))
             {
-                float lw = j["render"].value("line_width", renderer.lineWidth());
-                float nodePx = j["render"].value("node_diameter_px", renderer.nodeDiameterPx());
-                renderer.setLineWidth(lw);
-                renderer.setNodeDiameterPx(nodePx);
+                render.lineWidth = j["render"].value("line_width", render.lineWidth);
+                render.nodeDiameter = j["render"].value("node_diameter_px", render.nodeDiameter);
             }
 
             // Plotter config (supports new key and legacy "axidraw")

--- a/src/utils/Serialization.h
+++ b/src/utils/Serialization.h
@@ -5,9 +5,13 @@
 
 struct PageModel;
 class Camera;
-class Renderer;
 
 namespace serialization {
+
+struct RenderSettings {
+    float lineWidth{1.0f};
+    float nodeDiameter{8.0f};
+};
 
 // Save PageModel to JSON file at path. Pretty prints.
 // Returns true on success; false and fills errorOut on failure.
@@ -17,11 +21,11 @@ bool savePageModel(const PageModel& model, const std::string& filePath, std::str
 // Returns true on success; false and fills errorOut on failure.
 bool loadPageModel(PageModel& model, const std::string& filePath, std::string* errorOut = nullptr);
 
-// Save/Load full project (page + camera + renderer + plotter config) to JSON file.
-bool saveProject(const PageModel& model, const Camera& camera, const Renderer& renderer,
+// Save/Load full project (page + camera + render settings + plotter config) to JSON file.
+bool saveProject(const PageModel& model, const Camera& camera, const RenderSettings& render,
                  const PlotterConfig& plotter,
                  const std::string& filePath, std::string* errorOut = nullptr);
-bool loadProject(PageModel& model, Camera& camera, Renderer& renderer,
+bool loadProject(PageModel& model, Camera& camera, RenderSettings& render,
                  PlotterConfig& plotter,
                  const std::string& filePath, std::string* errorOut = nullptr);
 


### PR DESCRIPTION
## Summary
Decoupled renderer state from the `Renderer` class by introducing a `RenderSettings` struct for serialization. This change separates concerns between rendering implementation and project persistence.

## Key Changes
- Created `RenderSettings` struct in `serialization` namespace with `lineWidth` and `nodeDiameter` fields
- Removed `#include "Renderer.h"` dependency from `Serialization.cpp`
- Updated `saveProject()` and `loadProject()` function signatures to accept `RenderSettings` instead of `Renderer` reference
- Modified serialization logic to work with struct fields directly instead of calling renderer methods
- Updated `MainScreen` to:
  - Create temporary `RenderSettings` objects when loading/saving projects
  - Manually sync settings between `RenderSettings` and `Renderer` instance on load
  - Extract renderer state into `RenderSettings` before saving

## Implementation Details
- The `RenderSettings` struct provides sensible defaults (`lineWidth=1.0f`, `nodeDiameter=8.0f`)
- Serialization now operates on plain data structures rather than class instances, improving testability and reducing coupling
- The `Renderer` class retains its own state management; `RenderSettings` is purely for persistence

https://claude.ai/code/session_01NYYbiG58Byy9ETThVxPvz4