### PR TITLE
Refactor vcpkg dependencies: separate app features from test core

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           cmake -B build \
             -DBUILD_APP=OFF \
+            -DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON \
             -DCMAKE_TOOLCHAIN_FILE=/tmp/vcpkg/scripts/buildsystems/vcpkg.cmake \
             -DCMAKE_CXX_STANDARD=17
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ CMakeUserPresets.json
 
 # Local working project data (large binary-in-JSON, not source)
 page.json
+# vcpkg manifest-mode install root (when vcpkg is run outside build/)
+vcpkg_installed/

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,14 +3,21 @@
   "version-string": "0.1.0",
   "builtin-baseline": "b472291f295551b7127359ea38fdd2ca092f6f1b",
   "dependencies": [
-    "glfw3",
-    "glad",
-    { "name": "imgui", "features": ["glfw-binding", "opengl3-binding"] },
-    "fmt",
-    "glog",
-    "nlohmann-json",
     "gtest",
-    "curl"
-  ]
+    "glog"
+  ],
+  "default-features": ["app"],
+  "features": {
+    "app": {
+      "description": "GUI application dependencies (not needed for tests)",
+      "dependencies": [
+        "glfw3",
+        "glad",
+        { "name": "imgui", "features": ["glfw-binding", "opengl3-binding"] },
+        "fmt",
+        "nlohmann-json",
+        "curl"
+      ]
+    }
+  }
 }
-


### PR DESCRIPTION
## Summary
Reorganized vcpkg manifest to separate GUI application dependencies from core test dependencies, reducing build requirements when running tests in CI.

## Changes
- **vcpkg.json**: Restructured dependencies into a feature-based model
  - Moved core test dependencies (`gtest`, `glog`) to root `dependencies`
  - Created `app` feature containing GUI and rendering dependencies (glfw3, glad, imgui, fmt, nlohmann-json, curl)
  - Set `app` as default feature for local development builds
  - Removed `glog` from app feature (now in core)

- **.gitignore**: Added `vcpkg_installed/` to ignore vcpkg manifest-mode install root when vcpkg is run outside the build directory

- **.github/workflows/tests.yml**: Updated CI test build configuration
  - Added `-DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON` flag to skip app feature installation during test builds
  - Keeps `-DBUILD_APP=OFF` to disable app binary compilation

## Implementation Details
This change enables efficient CI test runs by only installing test dependencies (gtest, glog) without the overhead of GUI libraries (glfw3, glad, imgui, curl). Local development builds continue to include all dependencies via the default feature, maintaining the existing developer experience.

https://claude.ai/code/session_01HRRMoQFDDHPHWSU88V6hvP