### PR TITLE
Add dark mode toggle with light mode page rendering

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -27,11 +27,33 @@ uint64_t entityImageVersion(const Entity &entity)
 }
 }
 
+namespace
+{
+// Reserved BitmapRenderer texture id for the page fill quad. Entity ids are
+// non-negative, so a negative id can never collide with one.
+constexpr int kPageFillTexId = -1;
+
+const Color kDarkBackground{0.1f, 0.1f, 0.12f, 1.0f};
+const Color kLightBackground{0.5f, 0.5f, 0.5f, 1.0f};
+}
+
 Renderer::Renderer()
 {
    m_lines.init();
    m_images.init();
    m_floatImages.init();
+
+   m_pageFill.width_px = 1;
+   m_pageFill.height_px = 1;
+   m_pageFill.pixel_size_mm = 1.0f;
+   m_pageFill.pixels = {255};
+}
+
+void Renderer::setDarkMode(bool dark)
+{
+   m_darkMode = dark;
+   const Color &bg = dark ? kDarkBackground : kLightBackground;
+   glClearColor(bg.r, bg.g, bg.b, bg.a);
 }
 
 void Renderer::render(const Camera &camera, const PageModel &page, const InteractionState &uiState)
@@ -69,6 +91,12 @@ void Renderer::beginFrame(const Camera &camera, const PageModel &page, const Int
          for (const auto &path : ps.paths)
          {
             Color pathCol = entity.color;
+            if (!m_darkMode)
+            {
+               // Light mode: invert the layer color so default white ink
+               // renders black on the white page.
+               pathCol = Color(1.0f - pathCol.r, 1.0f - pathCol.g, 1.0f - pathCol.b, pathCol.a);
+            }
             for (size_t i = 1; i < path.points.size(); ++i)
             {
                m_lines.addLine(transform * path.points[i - 1], transform * path.points[i], pathCol);
@@ -209,7 +237,16 @@ void Renderer::shutdown()
 
 void Renderer::renderPage(const Camera &camera, const PageModel &page)
 {
-   Color outlineCol = Color(0.8f, 0.8f, 0.8f, 1.0f);
+   if (!m_darkMode)
+   {
+      // White page fill, drawn before any entity so it sits underneath.
+      // The 1x1 white bitmap is stretched over the full page extent.
+      Mat3 pageScale = Mat3::scale(page.page_width_mm, page.page_height_mm);
+      m_images.addBitmap(kPageFillTexId, m_pageFill, pageScale, 1);
+   }
+
+   Color outlineCol = m_darkMode ? Color(0.8f, 0.8f, 0.8f, 1.0f)
+                                 : Color(0.35f, 0.35f, 0.35f, 1.0f);
    // outline
 
    drawRect(Vec2(0.0f, 0.0f), Vec2(page.page_width_mm, page.page_height_mm), outlineCol);
@@ -219,7 +256,8 @@ void Renderer::renderPage(const Camera &camera, const PageModel &page)
    drawRect(Vec2(0.0f, 0.0f), Vec2(279.4f, 215.9f), outlineCol);
 
    // grid lines every 10mm
-   Color gridCol = Color(0.3f, 0.3f, 0.3f, 1.0f);
+   Color gridCol = m_darkMode ? Color(0.3f, 0.3f, 0.3f, 1.0f)
+                              : Color(0.85f, 0.85f, 0.85f, 1.0f);
    for (float x = 10.0f; x < page.page_width_mm; x += 10.0f)
    {
       m_lines.addLine(Vec2(x, 0.0f), Vec2(x, page.page_height_mm), gridCol);

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -35,6 +35,11 @@ public:
     float lineWidth() const { return m_lines.lineWidth(); }
     float nodeDiameterPx() const { return m_nodeDiameterPx; }
 
+    // Dark mode: dark background, no page fill, layer colors as authored.
+    // Light mode: gray background, white page, layer colors inverted (ink black).
+    void setDarkMode(bool dark);
+    bool darkMode() const { return m_darkMode; }
+
     void shutdown();
 
     int totalVertices() const { return static_cast<int>(m_lines.totalVertices()); }
@@ -47,6 +52,8 @@ private:
     BitmapRenderer m_images{};
     FloatImageRenderer m_floatImages{};
     float m_nodeDiameterPx{8.0f};
+    bool m_darkMode{true};
+    Bitmap m_pageFill{}; // 1x1 white bitmap stretched over the page in light mode
 
     void renderPage(const Camera &camera, const PageModel &page);
     void drawRect(const Vec2 &min, const Vec2 &max, const Color &col);

--- a/src/screens/MainScreen.gui.cpp
+++ b/src/screens/MainScreen.gui.cpp
@@ -48,6 +48,12 @@ void MainScreen::onGui()
             m_interaction.SetShowPathNodes(showNodes);
         }
 
+        bool darkMode = m_renderer.darkMode();
+        if (ImGui::Checkbox("Dark Mode", &darkMode))
+        {
+            m_renderer.setDarkMode(darkMode);
+        }
+
         ImGui::Separator();
         {
             Vec2 center = Vec2(m_page.page_width_mm, m_page.page_height_mm) * 0.5f;


### PR DESCRIPTION
## Summary
Implements a dark/light mode toggle for the renderer with distinct visual styling for each mode. In light mode, the page is rendered with a white background, inverted layer colors (so default white ink renders black), and adjusted grid/outline colors for visibility. Dark mode preserves the original dark background with colors as authored.

## Key Changes
- **Dark mode state management**: Added `m_darkMode` boolean to `Renderer` with `setDarkMode()` method and `darkMode()` accessor
- **Light mode page rendering**: 
  - White page fill (1x1 bitmap stretched to page dimensions) drawn underneath entities in light mode only
  - Inverted path colors in light mode so default white ink renders black on white page
  - Adjusted outline color (0.35, 0.35, 0.35) and grid color (0.85, 0.85, 0.85) for light mode visibility
- **Background colors**: Defined `kDarkBackground` (0.1, 0.1, 0.12) and `kLightBackground` (0.5, 0.5, 0.5) constants
- **UI integration**: Added "Dark Mode" checkbox to MainScreen GUI that toggles the renderer mode
- **Reserved texture ID**: Introduced `kPageFillTexId = -1` constant to avoid collision with entity texture IDs

## Implementation Details
- The 1x1 white bitmap (`m_pageFill`) is initialized in the `Renderer` constructor and stretched via `Mat3::scale()` to cover the full page extent
- Color inversion in light mode is applied during path rendering in `beginFrame()`, not at the bitmap level
- `glClearColor()` is updated when mode changes to reflect the appropriate background

https://claude.ai/code/session_01FrztDiMjbs3HsJSMDNmweU