### PR TITLE
Add project management system with file browser UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ src/
     SerialController.h/cpp  # Cross-platform USB serial (Win/macOS/Linux)
   utils/
     Serialization.h/cpp     # JSON project save/load (entities, filters, camera, plotter)
+    ProjectStore.h/cpp      # Standard projects dir (~/Documents/Minotaur/Projects), listing, delete
     ImageLoader.h/cpp       # Image loading (WIC on Windows, stb_image elsewhere)
     ImageCompression.h/cpp  # RLE + Base64 compression for bitmap serialization
     KdTree2D.h              # 2D spatial index (wraps nanoflann)
@@ -277,7 +278,11 @@ CoreXY kinematics: A = dx + dy, B = dx - dy (stepper motor mapping).
 
 ## Serialization
 
-Project state saves to JSON (`page.json`) via `src/utils/Serialization.cpp`.
+Project state saves to JSON via `src/utils/Serialization.cpp`. Projects live in a
+standard directory (`~/Documents/Minotaur/Projects`, see `src/utils/ProjectStore.cpp`);
+the default project is `default.json` there, a legacy `./page.json` is migrated on
+first launch, and an explicit path can still be passed as `argv[1]`. The "Projects"
+panel lists, opens, saves-as, creates, and deletes projects in that directory.
 Saved state includes: all entities (with payload data), filter chains (filter type
 name + parameters + enabled state), generator state (type name + float/string params),
 camera position/zoom, plotter config. Bitmap data uses RLE + Base64 compression.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,8 @@ int main(int argc, char *argv[]) {
     FilterRegistry::initDefaults();
     GeneratorRegistry::initDefaults();
     App app(2200, 1600, "Minotaur");
-    std::string projectPath = (argc > 1) ? argv[1] : "page.json";
+    // Empty path -> MainScreen resolves to the standard projects directory
+    std::string projectPath = (argc > 1) ? argv[1] : "";
     MainScreen screen(projectPath);
     app.run(screen);
     return 0;

--- a/src/screens/MainScreen.cpp
+++ b/src/screens/MainScreen.cpp
@@ -6,8 +6,10 @@
 #include "generators/pathset/SvgGenerator.h"
 #include "utils/ImageLoader.h"
 #include "utils/Clipboard.h"
+#include <filesystem>
 #include <iostream>
 #include <glog/logging.h>
+#include <fmt/format.h>
 #include "utils/Serialization.h"
 #include "plotters/PlotterConfig.h"
 
@@ -17,26 +19,112 @@ void MainScreen::onAttach(App &app)
     google::SetStderrLogging(google::GLOG_INFO);
 
     m_app = &app;
+
+    // No explicit path on the CLI: use the standard projects directory
+    if (m_projectPath.empty())
+        m_projectPath = projects::defaultProjectPath();
+
+    if (!loadProjectFrom(m_projectPath))
+    {
+        // Legacy fallback: older builds saved page.json in the working directory.
+        // Load it if present, but keep saving to the standard location.
+        bool migrated = false;
+        if (m_projectPath == projects::defaultProjectPath() &&
+            std::filesystem::exists("page.json"))
+        {
+            migrated = loadProjectFrom("page.json");
+            if (migrated)
+                LOG(INFO) << "Migrated legacy page.json; will save to " << m_projectPath;
+        }
+        if (!migrated)
+        {
+            // Fallback demo content
+            m_page.addGeneratedEntity(
+                std::make_unique<CircleGenerator>(),
+                Vec2(297.0f / 2.0f, 420.0f / 2.0f));
+        }
+    }
+}
+
+bool MainScreen::loadProjectFrom(const std::string &path)
+{
     std::string err;
     serialization::RenderSettings rs;
-    if (!serialization::loadProject(m_page, m_camera, rs, m_plotter.config(), m_projectPath, &err))
+    if (!serialization::loadProject(m_page, m_camera, rs, m_plotter.config(), path, &err))
     {
         if (!err.empty())
         {
-            LOG(WARNING) << "Failed to load page.json: " << err;
+            LOG(WARNING) << "Failed to load project '" << path << "': " << err;
         }
-        // Fallback demo content
-        m_page.addGeneratedEntity(
-            std::make_unique<CircleGenerator>(),
-            Vec2(297.0f / 2.0f, 420.0f / 2.0f));
+        return false;
+    }
+    m_renderer.setLineWidth(rs.lineWidth);
+    m_renderer.setNodeDiameterPx(rs.nodeDiameter);
+    // Sync AxiDraw state from loaded plotter config
+    m_plotter.syncStateFromConfig();
+    return true;
+}
+
+bool MainScreen::saveCurrentProject()
+{
+    std::string err;
+    // Keep pen positions in sync with the last known AxiDraw state
+    m_plotter.syncConfigFromState();
+    serialization::RenderSettings rs{m_renderer.lineWidth(), m_renderer.nodeDiameterPx()};
+    if (!serialization::saveProject(m_page, m_camera, rs, m_plotter.config(), m_projectPath, &err))
+    {
+        LOG(ERROR) << "Failed to save project '" << m_projectPath << "': " << err;
+        return false;
+    }
+    LOG(INFO) << "Saved project: " << m_projectPath;
+    m_projectListDirty = true;
+    return true;
+}
+
+void MainScreen::openProject(const std::string &path)
+{
+    if (path == m_projectPath)
+        return;
+
+    // Persist the current project before switching so nothing is lost
+    saveCurrentProject();
+
+    m_interaction.DeselectEntity();
+    m_interaction.ClearHover();
+    m_genStringBufs.clear();
+
+    if (loadProjectFrom(path))
+    {
+        m_projectPath = path;
+        LOG(INFO) << "Opened project: " << path;
     }
     else
     {
-        m_renderer.setLineWidth(rs.lineWidth);
-        m_renderer.setNodeDiameterPx(rs.nodeDiameter);
-        // Sync AxiDraw state from loaded plotter config
-        m_plotter.syncStateFromConfig();
+        // loadProject may have cleared entities before failing; restore the
+        // previous project (it was just saved above)
+        loadProjectFrom(m_projectPath);
     }
+}
+
+void MainScreen::createNewProject(const std::string &name)
+{
+    // Persist the current project before switching so nothing is lost
+    saveCurrentProject();
+
+    m_interaction.DeselectEntity();
+    m_interaction.ClearHover();
+    m_genStringBufs.clear();
+    m_page.entities.clear();
+    m_camera.reset();
+
+    // Pick a non-colliding path so New never overwrites an existing project
+    const std::string base = name.empty() ? "untitled" : name;
+    std::string path = projects::pathForName(base);
+    for (int i = 2; std::filesystem::exists(path); ++i)
+        path = projects::pathForName(fmt::format("{}-{}", base, i));
+
+    m_projectPath = path;
+    saveCurrentProject();
 }
 
 void MainScreen::onResize(int width, int height)
@@ -124,14 +212,7 @@ void MainScreen::onRender()
 void MainScreen::onDetach()
 {
     m_renderer.shutdown();
-    std::string err;
-    // Keep pen positions in sync with the last known AxiDraw state
-    m_plotter.syncConfigFromState();
-    serialization::RenderSettings rs{m_renderer.lineWidth(), m_renderer.nodeDiameterPx()};
-    if (!serialization::saveProject(m_page, m_camera, rs, m_plotter.config(), m_projectPath, &err))
-    {
-        LOG(ERROR) << "Failed to save page.json: " << err;
-    }
+    saveCurrentProject();
 }
 
 void MainScreen::onFilesDropped(const std::vector<std::string>& paths)

--- a/src/screens/MainScreen.gui.cpp
+++ b/src/screens/MainScreen.gui.cpp
@@ -1,6 +1,7 @@
 #include "MainScreen.h"
 #include <string>
 #include <cmath>
+#include <filesystem>
 #include <fmt/format.h>
 #include "filters/FilterChain.h"
 #include "filters/FilterRegistry.h"
@@ -9,8 +10,147 @@
 #include "generators/mesh/MeshGenerator.h"
 #include "core/Theme.h"
 
+static std::string humanFileSize(uint64_t bytes)
+{
+    if (bytes < 1024)
+        return fmt::format("{} B", bytes);
+    if (bytes < 1024ull * 1024ull)
+        return fmt::format("{:.1f} KB", bytes / 1024.0);
+    return fmt::format("{:.1f} MB", bytes / (1024.0 * 1024.0));
+}
+
+void MainScreen::drawProjectsPanel()
+{
+    if (ImGui::Begin("Projects"))
+    {
+        // Refresh the cached directory listing when something changed it
+        if (m_projectListDirty)
+        {
+            m_projectList = projects::listProjects();
+            m_projectListDirty = false;
+        }
+
+        const std::string currentName = std::filesystem::path(m_projectPath).stem().string();
+        ImGui::Text("Current: %s", currentName.c_str());
+        ImGui::TextDisabled("%s", m_projectPath.c_str());
+
+        if (ImGui::Button("Save"))
+        {
+            saveCurrentProject();
+        }
+        ImGui::SameLine();
+
+        ImGui::SetNextItemWidth(160.0f);
+        ImGui::InputTextWithHint("##projectname", "project name",
+                                 m_projectNameBuf, sizeof(m_projectNameBuf));
+        ImGui::SameLine();
+        {
+            const bool haveName = (m_projectNameBuf[0] != '\0');
+            if (!haveName) ImGui::BeginDisabled();
+            if (ImGui::Button("Save As"))
+            {
+                m_projectPath = projects::pathForName(m_projectNameBuf);
+                saveCurrentProject();
+                m_projectNameBuf[0] = '\0';
+            }
+            if (!haveName) ImGui::EndDisabled();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("New"))
+        {
+            createNewProject(m_projectNameBuf);
+            m_projectNameBuf[0] = '\0';
+        }
+
+        ImGui::Separator();
+        ImGui::Text("%d project(s) in library", static_cast<int>(m_projectList.size()));
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Refresh"))
+        {
+            m_projectListDirty = true;
+        }
+
+        if (ImGui::BeginTable("ProjectsTable", 4,
+                              ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV |
+                              ImGuiTableFlags_ScrollY, ImVec2(0, 260)))
+        {
+            ImGui::TableSetupScrollFreeze(0, 1);
+            ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("Modified", ImGuiTableColumnFlags_WidthFixed, 120.0f);
+            ImGui::TableSetupColumn("Size", ImGuiTableColumnFlags_WidthFixed, 70.0f);
+            ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 110.0f);
+            ImGui::TableHeadersRow();
+
+            for (const auto &info : m_projectList)
+            {
+                const bool isCurrent = (info.path == m_projectPath);
+                ImGui::TableNextRow();
+                ImGui::PushID(info.path.c_str());
+
+                ImGui::TableSetColumnIndex(0);
+                if (isCurrent)
+                    ImGui::TextColored(ImVec4(0.4f, 1.0f, 0.6f, 1.0f), "%s (open)", info.name.c_str());
+                else
+                    ImGui::TextUnformatted(info.name.c_str());
+
+                ImGui::TableSetColumnIndex(1);
+                ImGui::TextUnformatted(info.modifiedString.c_str());
+
+                ImGui::TableSetColumnIndex(2);
+                ImGui::TextUnformatted(humanFileSize(info.sizeBytes).c_str());
+
+                ImGui::TableSetColumnIndex(3);
+                if (isCurrent) ImGui::BeginDisabled();
+                if (ImGui::SmallButton("Open"))
+                {
+                    openProject(info.path);
+                }
+                ImGui::SameLine();
+                if (ImGui::SmallButton("x"))
+                {
+                    m_pendingDeletePath = info.path;
+                }
+                if (isCurrent) ImGui::EndDisabled();
+
+                ImGui::PopID();
+            }
+            ImGui::EndTable();
+        }
+
+        // Delete confirmation
+        if (!m_pendingDeletePath.empty() && !ImGui::IsPopupOpen("Delete Project?"))
+        {
+            ImGui::OpenPopup("Delete Project?");
+        }
+        if (ImGui::BeginPopupModal("Delete Project?", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+        {
+            const std::string delName = std::filesystem::path(m_pendingDeletePath).stem().string();
+            ImGui::Text("Delete project '%s'?", delName.c_str());
+            ImGui::TextDisabled("This cannot be undone.");
+            ImGui::Separator();
+            if (ImGui::Button("Delete", ImVec2(120, 0)))
+            {
+                projects::deleteProject(m_pendingDeletePath);
+                m_pendingDeletePath.clear();
+                m_projectListDirty = true;
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Cancel", ImVec2(120, 0)))
+            {
+                m_pendingDeletePath.clear();
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
+        }
+    }
+    ImGui::End();
+}
+
 void MainScreen::onGui()
 {
+    drawProjectsPanel();
+
     if (ImGui::Begin("Controls"))
     {
         ImGui::Text("Viewport");

--- a/src/screens/MainScreen.h
+++ b/src/screens/MainScreen.h
@@ -7,12 +7,15 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 #include "plotters/PlotterManager.h"
+#include "utils/ProjectStore.h"
 
 class MainScreen : public IScreen
 {
 public:
-    explicit MainScreen(const std::string &projectPath = "page.json")
+    // Empty path means "use the standard projects directory" (resolved in onAttach).
+    explicit MainScreen(const std::string &projectPath = "")
         : m_projectPath(projectPath) {}
 
     void onAttach(App &app) override;
@@ -39,6 +42,19 @@ private:
 
     // Project file path
     std::string m_projectPath;
+
+    // Project management (implemented in MainScreen.cpp, panel in MainScreen.gui.cpp)
+    bool loadProjectFrom(const std::string &path);
+    bool saveCurrentProject();
+    void openProject(const std::string &path);
+    void createNewProject(const std::string &name);
+    void drawProjectsPanel();
+
+    // Cached listing of the standard projects directory for the Projects panel
+    std::vector<projects::ProjectInfo> m_projectList;
+    bool m_projectListDirty{true};
+    char m_projectNameBuf[128]{};
+    std::string m_pendingDeletePath;
 
     // Per-entity string parameter input buffers for the generator UI panel.
     // Keyed by "<entityId>:<paramKey>".

--- a/src/utils/ProjectStore.cpp
+++ b/src/utils/ProjectStore.cpp
@@ -1,0 +1,159 @@
+#include "utils/ProjectStore.h"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <filesystem>
+
+#include <glog/logging.h>
+
+namespace fs = std::filesystem;
+
+namespace projects
+{
+
+static fs::path homeDirectory()
+{
+	if (const char *home = std::getenv("HOME"))
+		return fs::path(home);
+	if (const char *profile = std::getenv("USERPROFILE"))
+		return fs::path(profile);
+	return fs::current_path();
+}
+
+std::string projectsDirectory()
+{
+	fs::path dir = homeDirectory() / "Documents" / "Minotaur" / "Projects";
+	std::error_code ec;
+	fs::create_directories(dir, ec);
+	if (ec)
+	{
+		LOG(WARNING) << "Failed to create projects directory " << dir.string()
+		             << " (" << ec.message() << "); falling back to ./projects";
+		dir = fs::path("projects");
+		fs::create_directories(dir, ec);
+	}
+	return dir.string();
+}
+
+std::string defaultProjectPath()
+{
+	return (fs::path(projectsDirectory()) / "default.json").string();
+}
+
+std::string pathForName(const std::string &name)
+{
+	std::string clean;
+	clean.reserve(name.size());
+	for (char c : name)
+	{
+		const bool ok = std::isalnum(static_cast<unsigned char>(c)) ||
+		                c == '-' || c == '_' || c == ' ' || c == '.';
+		clean.push_back(ok ? c : '_');
+	}
+
+	// Trim leading/trailing spaces and dots (hidden files, "name. " typos)
+	const auto first = clean.find_first_not_of(" .");
+	const auto last = clean.find_last_not_of(" .");
+	clean = (first == std::string::npos) ? std::string{} : clean.substr(first, last - first + 1);
+
+	// Strip a typed ".json" so "foo.json" doesn't become "foo.json.json"
+	const std::string ext = ".json";
+	if (clean.size() > ext.size() && clean.compare(clean.size() - ext.size(), ext.size(), ext) == 0)
+		clean.erase(clean.size() - ext.size());
+
+	if (clean.empty())
+		clean = "untitled";
+
+	return (fs::path(projectsDirectory()) / (clean + ext)).string();
+}
+
+static int64_t toUnixSeconds(fs::file_time_type tp)
+{
+	using namespace std::chrono;
+	// C++17 has no clock_cast; convert via the offset between the two clocks' nows
+	const auto sys = time_point_cast<system_clock::duration>(
+		tp - fs::file_time_type::clock::now() + system_clock::now());
+	return duration_cast<seconds>(sys.time_since_epoch()).count();
+}
+
+static std::string formatLocalTime(int64_t unixSeconds)
+{
+	std::time_t t = static_cast<std::time_t>(unixSeconds);
+	std::tm tmv{};
+#ifdef _WIN32
+	localtime_s(&tmv, &t);
+#else
+	localtime_r(&t, &tmv);
+#endif
+	char buf[32];
+	if (std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", &tmv) == 0)
+		return {};
+	return buf;
+}
+
+std::vector<ProjectInfo> listProjects()
+{
+	std::vector<ProjectInfo> out;
+	std::error_code ec;
+	fs::directory_iterator it(projectsDirectory(), ec);
+	if (ec)
+	{
+		LOG(WARNING) << "Failed to list projects directory: " << ec.message();
+		return out;
+	}
+
+	for (const auto &entry : it)
+	{
+		if (!entry.is_regular_file(ec) || ec)
+			continue;
+		if (entry.path().extension() != ".json")
+			continue;
+
+		ProjectInfo info;
+		info.name = entry.path().stem().string();
+		info.path = entry.path().string();
+		info.sizeBytes = static_cast<uint64_t>(entry.file_size(ec));
+		if (ec)
+			info.sizeBytes = 0;
+		const auto mtime = entry.last_write_time(ec);
+		if (!ec)
+		{
+			info.modifiedUnix = toUnixSeconds(mtime);
+			info.modifiedString = formatLocalTime(info.modifiedUnix);
+		}
+		out.push_back(std::move(info));
+	}
+
+	std::sort(out.begin(), out.end(), [](const ProjectInfo &a, const ProjectInfo &b) {
+		return a.modifiedUnix > b.modifiedUnix;
+	});
+	return out;
+}
+
+bool deleteProject(const std::string &path)
+{
+	// Only ever delete .json files inside the projects directory
+	std::error_code ec;
+	const fs::path target = fs::weakly_canonical(fs::path(path), ec);
+	const fs::path dir = fs::weakly_canonical(fs::path(projectsDirectory()), ec);
+	const std::string targetStr = target.string();
+	const std::string dirStr = dir.string();
+	if (target.extension() != ".json" ||
+	    targetStr.compare(0, dirStr.size(), dirStr) != 0)
+	{
+		LOG(ERROR) << "Refusing to delete non-project file: " << path;
+		return false;
+	}
+
+	const bool ok = fs::remove(target, ec) && !ec;
+	if (!ok)
+		LOG(ERROR) << "Failed to delete project " << path << ": " << ec.message();
+	else
+		LOG(INFO) << "Deleted project: " << path;
+	return ok;
+}
+
+}

--- a/src/utils/ProjectStore.h
+++ b/src/utils/ProjectStore.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Standard on-disk location for project .json files, plus helpers for
+// listing and managing the projects stored there.
+namespace projects
+{
+
+struct ProjectInfo
+{
+	std::string name;           // file stem, e.g. "spirals"
+	std::string path;           // full path to the .json file
+	uint64_t sizeBytes{0};
+	int64_t modifiedUnix{0};    // seconds since epoch, for sorting
+	std::string modifiedString; // "YYYY-MM-DD HH:MM" in local time
+};
+
+// Directory where project files live (~/Documents/Minotaur/Projects,
+// falling back to ./projects if the home directory is unavailable).
+// Created on first call if missing.
+std::string projectsDirectory();
+
+// <projectsDirectory>/default.json - used when no path is given on the CLI.
+std::string defaultProjectPath();
+
+// Sanitized "<projectsDirectory>/<name>.json" for a user-entered name.
+std::string pathForName(const std::string &name);
+
+// All *.json files in the projects directory, newest first.
+std::vector<ProjectInfo> listProjects();
+
+// Remove a project file. Returns true on success.
+bool deleteProject(const std::string &path);
+
+}


### PR DESCRIPTION
## Summary
Implements a complete project management system for Minotaur, replacing the hardcoded `page.json` workflow with a standard projects directory (`~/Documents/Minotaur/Projects`) and a new ImGui panel for browsing, opening, creating, and deleting projects.

## Key Changes

- **New `ProjectStore` utility** (`src/utils/ProjectStore.h/cpp`):
  - `projectsDirectory()` - resolves to `~/Documents/Minotaur/Projects` with fallback to `./projects`
  - `pathForName()` - sanitizes user-entered project names and generates safe file paths
  - `listProjects()` - enumerates all `.json` files in the projects directory with metadata (size, modification time)
  - `deleteProject()` - safely removes project files with path validation
  - Helper functions for Unix timestamp conversion and human-readable time formatting

- **Enhanced `MainScreen` project lifecycle**:
  - `loadProjectFrom(path)` - extracted from `onAttach()` for reusable project loading
  - `saveCurrentProject()` - extracted from `onDetach()` for explicit save operations
  - `openProject(path)` - switches between projects with automatic persistence
  - `createNewProject(name)` - creates new projects with collision avoidance
  - Default project path resolves to `defaultProjectPath()` when no CLI argument provided
  - Legacy migration: automatically loads `page.json` if present and saves to standard location going forward

- **New Projects panel UI** (`MainScreen.gui.cpp`):
  - Displays current project name and path
  - Quick save, save-as, and new project buttons
  - Sortable table listing all projects (name, modification time, file size)
  - Open/delete buttons per project with confirmation dialog
  - Refresh button to reload directory listing
  - Disabled controls prevent operations on the currently open project

- **Updated entry point** (`main.cpp`):
  - Empty CLI argument now resolves to standard projects directory instead of hardcoded `page.json`

## Implementation Details

- File path sanitization strips non-alphanumeric characters (except `-`, `_`, `.`, space) and trims leading/trailing dots to prevent hidden files and typos
- Project listing is cached in `MainScreen` and marked dirty when projects are created/deleted to avoid repeated filesystem scans
- Delete operations validate that the target is a `.json` file within the projects directory before removal
- Time formatting uses platform-specific `localtime_r` (POSIX) / `localtime_s` (Windows) for thread safety
- File size display uses human-readable units (B, KB, MB)

https://claude.ai/code/session_01HextN4UtdJk4YJ2ZumhMuv